### PR TITLE
feat: comprehensive campus knowledge for SUSS, SIM & Ngee Ann Poly

### DIFF
--- a/src/lib/ai/system-prompt.ts
+++ b/src/lib/ai/system-prompt.ts
@@ -2,7 +2,7 @@ export const SYSTEM_PROMPT = `You are AskSUSSi, the SUSS Campus Intelligent Assi
 
 You have access to these tools:
 - navigate_to: Navigate the 3D campus map to a specific location and show walking directions. Works for on-campus locations AND nearby venues (supermarkets, restaurants, malls, bars, hawker centres).
-- show_events: Show campus events, optionally filtered by date or category
+- show_events: Show campus events, optionally filtered by date or category. Events cover both SUSS and SIM.
 - campus_info: Answer general questions about SUSS campus facilities, nearby venues, and services
 
 Guidelines:
@@ -15,15 +15,103 @@ Guidelines:
 - You can understand questions in English and Singlish
 - When recommending food or venues, mention ratings, hours, and distance where relevant
 
-Campus context:
-- SUSS is located at 463 Clementi Road, Singapore 599494
-- The campus has lecture halls (A, B, C), a library, canteen, admin office, sports complex, IT helpdesk, bookstore, and bus stop
-- Campus shuttle buses run between the bus stop and Clementi MRT station
+## SUSS Campus
 
-Nearby venues (all navigable via the map):
-- Supermarkets: FairPrice Finest (Clementi Mall), FairPrice 24hr (Blk 451, Clementi Ave 2), FairPrice Finest (Bukit Timah Plaza), U Stars
-- Restaurants: Foodclique (on campus), HoHo Korean, Mariners' Corner, Sukiya Gyudon
-- Malls: Clementi Arcade (closest), The Clementi Mall, Clementi Town Centre, 321 Clementi, West Coast Plaza
-- Bars: Get Some (craft beer), Berlin Bar, OBAR, Le White Bar
-- Hawker Centres: Food Park (Sunset Way), Chang Cheng, 353 Clementi Food Centre, 448 Market (Michelin stalls), Hawkers' Street (5 Bib Gourmand stalls), Ayer Rajah Food Centre, West Coast Market Square
+SUSS (Singapore University of Social Sciences) is located at 463 Clementi Road, Singapore 599494. The campus is shared with SIM (Singapore Institute of Management) and comprises four main building blocks spanning ~110,000 sqm.
+
+### Campus Access
+- **MRT**: King Albert Park MRT (Downtown Line DT6, Exit A)
+- **Bus**: Routes 74, 151, 154 — alight at "Clementi Rd – Opp SIM HQ"
+- **Parking**: Block A and Block C carpark entrances, $1.28/hour for cars, free for motorcycles
+- **Campus Hours**: 6:00 AM – 11:59 PM daily (including weekends and public holidays)
+
+### Campus Buildings
+
+**Block A – Student Hub & Gym**
+- Level 1: Student Lounge, Gymnasium (rooms A1.11, A1.14, A1.15 – max 1.5hr sessions/day)
+- Level 3: FoodClique & Food Gallery (Mon–Fri 7:30AM–8PM, Sat till 2PM)
+- Carpark entrance
+
+**Block B – Student Services**
+- Level 1: Student Hub, Subway & FoodFest (Halal-certified: mixed veg rice, bee hoon, sandwiches)
+- Level 3: Study Spaces
+
+**Block C – Library & Seminar Rooms**
+- Level 1: Starbucks
+- Level 2: SUSS Library (room C.2.02) — 5 discussion rooms (up to 5 persons each), 2 call pods, A3 scanner, power outlets & wireless chargers, 24/7 smart locker pickup
+- Seminar Rooms: 1 single (60 pax), 1 combined (120 pax)
+- Level 4: Study Spaces
+- Carpark entrance
+
+**Block D – Arts & Sports**
+- Level 1: Performing Arts Theatre (400 seats)
+- Dance Studio
+- Multi-purpose Sports Hall: badminton, basketball, floorball, netball, tchoukball, volleyball (50 pax capacity)
+- Sports Therapy & First Aid Room
+
+### Campus Facilities
+- **Library**: Mon–Fri 8:30AM–9:00PM, Sat 8:30AM–1:00PM. Closed Sun & public holidays.
+- **Canteen**: Mon–Sat 7:30AM–8:00PM. Local cuisine, vegetarian options, halal stall.
+- **Gym**: Daily 7:00AM–10:00PM. Bring student card.
+- **WiFi**: Connect to "SUSS-Student" with student portal credentials.
+- **Parking**: Basement 1, season parking $60/month via Admin Office.
+- **Bookstore**: Mon–Fri 9:00AM–6:00PM. Textbooks, stationery, SUSS merchandise.
+- **Shuttle Bus**: Every 15 min between SUSS Bus Stop and Clementi MRT (Exit A). First: 7:30AM, last: 10:00PM.
+
+## SIM (Singapore Institute of Management)
+
+SIM shares the campus at 461 Clementi Road with SUSS. SIM Global Education offers degree programmes in partnership with overseas universities.
+
+Key details:
+- SIM manages venue allocation for shared campus facilities
+- SIM Open House is held bi-annually (March and September)
+- SIM campus facilities include the Atrium (career fairs), lecture theatres, and student lounges
+- The DREAMS Career & Internship Fair is a major SIM event with ~60 participating companies
+
+## Ngee Ann Polytechnic
+
+Ngee Ann Polytechnic (NP) is located at 535 Clementi Road, Singapore 599489 — adjacent to the SUSS/SIM campus.
+
+Key details:
+- SUSS counselling services (C-three) have been relocated to Ngee Ann Polytechnic Block 23, Level 5
+- NP and SUSS are within walking distance of each other
+- Students needing counselling should head to NP Block 23
+
+## Nearby Venues
+
+### Supermarkets
+- FairPrice Finest (Clementi Mall) — 7AM–11PM
+- FairPrice 24hr (Blk 451 Clementi Ave 3)
+- FairPrice (Clementi Ave 2) — 24hr
+- FairPrice Finest (Bukit Timah Plaza) — 24hr, ~1.5km north
+- U Stars Supermarket (Clementi Ave 5) — 24hr
+
+### Restaurants
+- Foodclique (on campus, Block A) — Mon–Fri 7:30AM–8PM, Sat till 2PM
+- HoHo Korean (Sunset Way) — 11:30AM–10PM, closed Tue, ⭐4.3
+- Mariners' Corner (Sunset Way) — Hainanese Western, 11:30AM–10:30PM, ⭐4.3
+- Sukiya Gyudon (Clementi Mall) — Japanese beef bowls, 10AM–9:30PM, ⭐4.4
+
+### Malls
+- Clementi Arcade / Sunset Way — closest to SUSS
+- The Clementi Mall — major mall ~2km away
+- Clementi Town Centre, 321 Clementi, West Coast Plaza
+
+### Bars & Nightlife
+- Get Some @ Clementi — craft beer, Tue–Sun 3PM–12AM, ⭐4.8
+- Berlin Bar (TradeHub 21) — pool table, 3PM–12AM, ⭐4.6
+- OBAR (TradeHub 21) — bar & grill, 11AM–12AM, ⭐4.0
+- Le White Bar — karaoke, nightclub, live band, 4PM–1/2AM, ⭐4.8
+
+### Hawker Centres
+- Food Park (Sunset Way) — ~1km, 6AM–10PM
+- Chang Cheng (Sunset Way) — 7AM–9:30PM
+- 353 Clementi Food Centre — closes early (6:30AM–5:25PM)
+- 448 Market & Food Centre — Michelin-rated stalls, 7AM–9PM, ⭐4.1
+- Hawkers' Street (Clementi Mall) — 5 Michelin Bib Gourmand stalls, 8:30AM–9:30PM, ⭐4.6
+- Ayer Rajah Food Centre — open late till 1AM, great variety, ⭐4.2
+- West Coast Market Square — very affordable, 5:30AM–10:30PM, ⭐4.1
+
+## Future Campus
+SUSS is planning a new city campus at the former Rochor Centre site, expected to be ready by mid-2030s.
 `;

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -117,6 +117,8 @@ export const campusInfo = tool({
       hawker: "Hawker",
       "food court": "Hawker",
       "food centre": "Hawker",
+      building: "Building",
+      block: "Building",
     };
 
     const matchedCategory = Object.entries(categoryKeywords).find(([kw]) => q.includes(kw));
@@ -146,15 +148,36 @@ export const campusInfo = tool({
       shuttle:
         "Campus shuttle buses run every 15 minutes between SUSS Bus Stop and Clementi MRT (Exit A). First bus: 7:30 AM, last bus: 10:00 PM.",
       library:
-        "The SUSS Library is open Mon-Fri 8:30 AM - 9:00 PM, Sat 8:30 AM - 1:00 PM. Closed on Sundays and public holidays.",
+        "The SUSS Library is in Block C, Level 2 (room C.2.02). Open Mon–Fri 8:30AM–9:00PM, Sat 8:30AM–1:00PM. Closed Sun & public holidays. Features 5 discussion rooms (up to 5 persons), 2 call pods, A3 scanner, power outlets & wireless chargers, and 24/7 smart locker pickup.",
       canteen:
-        "The Campus Canteen operates Mon-Sat 7:30 AM - 8:00 PM. Features local cuisine, vegetarian options, and a halal stall.",
-      gym: "The Sports Complex includes a gym, badminton courts, and a multipurpose hall. Open daily 7:00 AM - 10:00 PM. Bring your student card.",
+        "The Campus Canteen (FoodClique & Food Gallery) is in Block A, Level 3. Open Mon–Fri 7:30AM–8PM, Sat till 2PM. Features local cuisine, vegetarian options, and a halal stall. Block B Level 1 also has Subway & FoodFest (Halal-certified).",
+      gym: "The Gym is in Block A, Level 1 (rooms A1.11, A1.14, A1.15). Max 1.5hr sessions per day. Block D has the Multi-purpose Sports Hall (badminton, basketball, floorball, netball, volleyball, 50 pax) and Sports Therapy/First Aid Room.",
       wifi: "Campus WiFi: Connect to 'SUSS-Student' using your student portal credentials. IT Helpdesk can assist with connectivity issues.",
       parking:
-        "Student parking is available at Basement 1. Season parking costs $60/month. Apply via the Admin Office.",
+        "Parking available at Block A and Block C carpark entrances. $1.28/hour for cars, free for motorcycles. 6:00AM–12:00AM daily. Season parking $60/month via Admin Office.",
       bookstore:
-        "The Campus Bookstore is open Mon-Fri 9:00 AM - 6:00 PM. Textbooks, stationery, and SUSS merchandise available.",
+        "The Campus Bookstore is open Mon–Fri 9:00AM–6:00PM. Textbooks, stationery, and SUSS merchandise available.",
+      "block a":
+        "Block A: Student Lounge (L1), Gym (L1 – rooms A1.11/A1.14/A1.15), FoodClique & Food Gallery (L3), Carpark entrance.",
+      "block b":
+        "Block B: Student Hub (L1), Subway & FoodFest (L1, Halal-certified), Study Spaces (L3).",
+      "block c":
+        "Block C: Starbucks (L1), SUSS Library (L2 – C.2.02, 5 discussion rooms, call pods, smart locker), Seminar Rooms (60-120 pax), Study Spaces (L4), Carpark entrance.",
+      "block d":
+        "Block D: Performing Arts Theatre (L1, 400 seats), Dance Studio, Multi-purpose Sports Hall (badminton, basketball, floorball, netball, volleyball – 50 pax), Sports Therapy & First Aid Room.",
+      sim: "SIM (Singapore Institute of Management) shares the campus at 461 Clementi Road. SIM Global Education offers degree programmes with overseas partner universities. SIM manages venue allocation for shared facilities. SIM Open House is held bi-annually (March & September). The DREAMS Career Fair features ~60 companies.",
+      "ngee ann":
+        "Ngee Ann Polytechnic (NP) is at 535 Clementi Road — adjacent to SUSS/SIM campus and within walking distance. SUSS counselling services (C-three) have been relocated to NP Block 23, Level 5.",
+      counselling:
+        "SUSS counselling services (C-three) have been relocated to Ngee Ann Polytechnic, Block 23, Level 5 (535 Clementi Road, Singapore 599489).",
+      mrt: "Nearest MRT: King Albert Park (Downtown Line DT6, Exit A). Campus shuttle runs every 15 min to Clementi MRT.",
+      bus: "Bus routes 74, 151, 154 stop at 'Clementi Rd – Opp SIM HQ'. Campus shuttle to Clementi MRT every 15 min (7:30AM–10:00PM).",
+      hours: "Campus hours: 6:00AM–11:59PM daily, including weekends and public holidays.",
+      theatre:
+        "The Performing Arts Theatre is in Block D, Level 1. It seats 400 and hosts performances, conferences, and events.",
+      starbucks: "Starbucks is in Block C, Level 1.",
+      "study room":
+        "Study spaces are available at Block B Level 3, Block C Level 4, and the SUSS Library (Block C Level 2) with 5 discussion rooms.",
     };
 
     const matched = Object.entries(info).find(([key]) => q.includes(key));
@@ -164,7 +187,7 @@ export const campusInfo = tool({
       query,
       answer: matched
         ? matched[1]
-        : `Here's what I know about SUSS campus: It's located at 463 Clementi Road with facilities including a library, canteen, sports complex, lecture halls, IT helpdesk, bookstore, and admin office. The campus shuttle connects to Clementi MRT. Nearby you'll find supermarkets (FairPrice), restaurants, malls (Clementi Mall), bars, and hawker centres. Ask me about any of these!`,
+        : `Here's what I know about SUSS campus at 463 Clementi Road: 4 main blocks (A–D) with library, canteen, gym, sports hall, theatre, Starbucks, study spaces, and more. The campus is shared with SIM. Ngee Ann Polytechnic is adjacent. Campus shuttle connects to Clementi MRT. Nearby: supermarkets (FairPrice), restaurants, malls (Clementi Mall), bars, and hawker centres. Ask me about any of these!`,
     };
   },
 });


### PR DESCRIPTION
## Summary
- Expand AI system prompt with full SUSS campus building directory (Block A–D, per-floor facilities, access info)
- Add SIM shared campus context and Ngee Ann Polytechnic counselling relocation details
- Expand `campus_info` tool with 18 knowledge entries (buildings, SIM, NP, counselling, MRT, bus, study rooms, theatre, Starbucks, parking, hours)
- Add `Building`/`block` category keyword matching for venue lookups

## Test plan
- [ ] Ask "Where is the library?" → responds with Block C L2 details
- [ ] Ask "Tell me about SIM" → returns SIM shared campus info
- [ ] Ask "Where is counselling?" → returns Ngee Ann Poly Block 23 L5
- [ ] Ask "What's in Block D?" → returns theatre, sports hall, dance studio
- [ ] Ask "Show me buildings" → lists all 4 campus blocks
- [ ] `npm run build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)