### PR TITLE
feat: pin nav to street view, nearby events, resizable transparent sidebar

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import Image from "next/image";
 import dynamic from "next/dynamic";
-import { Volume2, VolumeX } from "lucide-react";
+import { Volume2, VolumeX, Minus, Maximize2, GripVertical } from "lucide-react";
 import { APIProvider } from "@vis.gl/react-google-maps";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAppStore } from "@/store/app-store";
@@ -23,37 +23,81 @@ const MapView = dynamic(() => import("@/components/map/MapView"), {
   ),
 });
 
+const MIN_WIDTH = 320;
+const MAX_WIDTH = 600;
+const DEFAULT_WIDTH = 400;
+
 export default function AppShell() {
   const activePanel = useAppStore((s) => s.activePanel);
   const setActivePanel = useAppStore((s) => s.setActivePanel);
   const ttsEnabled = useAppStore((s) => s.ttsEnabled);
   const setTtsEnabled = useAppStore((s) => s.setTtsEnabled);
   const [mobileSheetOpen, setMobileSheetOpen] = useState(true);
+  const [minimized, setMinimized] = useState(false);
+  const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH);
+  const isResizing = useRef(false);
+  const startX = useRef(0);
+  const startWidth = useRef(DEFAULT_WIDTH);
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent | React.TouchEvent) => {
+      e.preventDefault();
+      isResizing.current = true;
+      startX.current =
+        "touches" in e ? e.touches[0].clientX : e.clientX;
+      startWidth.current = panelWidth;
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+    },
+    [panelWidth]
+  );
+
+  useEffect(() => {
+    const handleMove = (e: MouseEvent | TouchEvent) => {
+      if (!isResizing.current) return;
+      const clientX =
+        "touches" in e ? e.touches[0].clientX : e.clientX;
+      const delta = clientX - startX.current;
+      const newWidth = Math.min(
+        MAX_WIDTH,
+        Math.max(MIN_WIDTH, startWidth.current + delta)
+      );
+      setPanelWidth(newWidth);
+    };
+
+    const handleUp = () => {
+      if (!isResizing.current) return;
+      isResizing.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+
+    window.addEventListener("mousemove", handleMove);
+    window.addEventListener("mouseup", handleUp);
+    window.addEventListener("touchmove", handleMove);
+    window.addEventListener("touchend", handleUp);
+    return () => {
+      window.removeEventListener("mousemove", handleMove);
+      window.removeEventListener("mouseup", handleUp);
+      window.removeEventListener("touchmove", handleMove);
+      window.removeEventListener("touchend", handleUp);
+    };
+  }, []);
 
   return (
     <div className="h-dvh w-full flex flex-col md:flex-row overflow-hidden">
+      {/* Desktop sidebar */}
       <aside
         aria-label="Chat and Events"
+        style={{ width: minimized ? 0 : panelWidth }}
         className={`
-          md:w-[400px] md:h-full md:relative md:border-r md:flex md:flex-col
-          fixed bottom-0 left-0 right-0 z-30
-          ${mobileSheetOpen ? "h-[55dvh]" : "h-12"}
-          md:h-full
-          bg-background transition-all duration-300
-          flex flex-col
-          rounded-t-2xl md:rounded-none shadow-[0_-4px_12px_rgba(0,0,0,0.1)] md:shadow-none
+          hidden md:flex md:flex-col md:relative md:h-full
+          bg-background/80 backdrop-blur-xl border-r border-white/10
+          transition-[width] duration-300 ease-in-out overflow-hidden shrink-0
         `}
       >
-        <button
-          type="button"
-          aria-label={mobileSheetOpen ? "Collapse panel" : "Expand panel"}
-          className="md:hidden flex justify-center py-2 shrink-0"
-          onClick={() => setMobileSheetOpen(!mobileSheetOpen)}
-        >
-          <div className="w-8 h-1 rounded-full bg-muted-foreground/30" />
-        </button>
-
-        <div className="flex items-center justify-between px-4 py-2.5 border-b bg-surface-brand text-surface-brand-foreground shrink-0 md:rounded-none rounded-t-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-2.5 border-b bg-surface-brand/90 backdrop-blur text-surface-brand-foreground shrink-0">
           <div className="flex items-center gap-2.5">
             <Image
               src="/suss-logo.png"
@@ -64,7 +108,119 @@ export default function AppShell() {
               priority
             />
             <div className="h-5 w-px bg-white/25" />
-            <span className="text-xs font-semibold tracking-wide opacity-90">AskSUSSi</span>
+            <span className="text-xs font-semibold tracking-wide opacity-90">
+              AskSUSSi
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => setTtsEnabled(!ttsEnabled)}
+              className="flex items-center justify-center w-7 h-7 rounded-full bg-white/10 hover:bg-white/20 transition-colors text-white/80 hover:text-white"
+              title={ttsEnabled ? "Disable voice" : "Enable voice"}
+              aria-label={ttsEnabled ? "Disable voice" : "Enable voice"}
+            >
+              {ttsEnabled ? <Volume2 size={14} /> : <VolumeX size={14} />}
+            </button>
+            <button
+              type="button"
+              onClick={() => setMinimized(true)}
+              className="flex items-center justify-center w-7 h-7 rounded-full bg-white/10 hover:bg-white/20 transition-colors text-white/80 hover:text-white"
+              title="Minimize panel"
+              aria-label="Minimize panel"
+            >
+              <Minus size={14} />
+            </button>
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <Tabs
+          value={activePanel}
+          onValueChange={(v) => setActivePanel(v as "chat" | "events")}
+          className="flex-1 flex flex-col min-h-0"
+        >
+          <TabsList className="mx-3 mt-2 shrink-0">
+            <TabsTrigger value="chat" className="flex-1">
+              Chat
+            </TabsTrigger>
+            <TabsTrigger value="events" className="flex-1">
+              Events
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="chat" className="flex-1 min-h-0 mt-0">
+            <ChatPanel />
+          </TabsContent>
+          <TabsContent value="events" className="flex-1 min-h-0 mt-0 overflow-y-auto">
+            <EventsPanel />
+          </TabsContent>
+        </Tabs>
+      </aside>
+
+      {/* Desktop resize handle */}
+      {!minimized && (
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize panel"
+          className="hidden md:flex items-center justify-center w-2 cursor-col-resize hover:bg-primary/10 active:bg-primary/20 transition-colors group shrink-0"
+          onMouseDown={handleResizeStart}
+          onTouchStart={handleResizeStart}
+        >
+          <GripVertical
+            size={14}
+            className="text-muted-foreground/40 group-hover:text-muted-foreground/70 transition-colors"
+          />
+        </div>
+      )}
+
+      {/* Desktop minimize restore button */}
+      {minimized && (
+        <button
+          type="button"
+          onClick={() => setMinimized(false)}
+          className="hidden md:flex absolute top-3 left-3 z-30 items-center gap-1.5 px-3 py-2 bg-surface-brand/90 backdrop-blur text-surface-brand-foreground rounded-lg shadow-lg text-xs font-medium hover:bg-surface-brand transition-colors"
+          aria-label="Restore panel"
+        >
+          <Maximize2 size={14} />
+          AskSUSSi
+        </button>
+      )}
+
+      {/* Mobile bottom sheet */}
+      <aside
+        aria-label="Chat and Events (mobile)"
+        className={`
+          md:hidden fixed bottom-0 left-0 right-0 z-30
+          ${mobileSheetOpen ? "h-[55dvh]" : "h-12"}
+          bg-background/90 backdrop-blur-xl transition-all duration-300
+          flex flex-col
+          rounded-t-2xl shadow-[0_-4px_12px_rgba(0,0,0,0.1)]
+        `}
+      >
+        <button
+          type="button"
+          aria-label={mobileSheetOpen ? "Collapse panel" : "Expand panel"}
+          className="flex justify-center py-2 shrink-0"
+          onClick={() => setMobileSheetOpen(!mobileSheetOpen)}
+        >
+          <div className="w-8 h-1 rounded-full bg-muted-foreground/30" />
+        </button>
+
+        <div className="flex items-center justify-between px-4 py-2.5 border-b bg-surface-brand/90 backdrop-blur text-surface-brand-foreground shrink-0 rounded-t-2xl">
+          <div className="flex items-center gap-2.5">
+            <Image
+              src="/suss-logo.png"
+              alt="SUSS"
+              width={80}
+              height={28}
+              className="h-7 w-auto brightness-0 invert"
+              priority
+            />
+            <div className="h-5 w-px bg-white/25" />
+            <span className="text-xs font-semibold tracking-wide opacity-90">
+              AskSUSSi
+            </span>
           </div>
           <button
             type="button"
@@ -83,19 +239,26 @@ export default function AppShell() {
           className="flex-1 flex flex-col min-h-0"
         >
           <TabsList className="mx-3 mt-2 shrink-0">
-            <TabsTrigger value="chat" className="flex-1">Chat</TabsTrigger>
-            <TabsTrigger value="events" className="flex-1">Events</TabsTrigger>
+            <TabsTrigger value="chat" className="flex-1">
+              Chat
+            </TabsTrigger>
+            <TabsTrigger value="events" className="flex-1">
+              Events
+            </TabsTrigger>
           </TabsList>
           <TabsContent value="chat" className="flex-1 min-h-0 mt-0">
             <ChatPanel />
           </TabsContent>
-          <TabsContent value="events" className="flex-1 min-h-0 mt-0">
+          <TabsContent value="events" className="flex-1 min-h-0 mt-0 overflow-y-auto">
             <EventsPanel />
           </TabsContent>
         </Tabs>
       </aside>
 
-      <APIProvider apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || ""} version="alpha">
+      <APIProvider
+        apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || ""}
+        version="alpha"
+      >
         <main id="main-content" className="flex-1 h-full relative">
           <MapView />
           <RouteOverlay />

--- a/src/components/map/POIPopup.tsx
+++ b/src/components/map/POIPopup.tsx
@@ -1,18 +1,41 @@
 "use client";
 
-import { useCallback, useState } from "react";
-import { X, MapPin, Clock, Star, Navigation } from "lucide-react";
+import { useCallback, useState, useMemo } from "react";
+import { X, MapPin, Clock, Star, Navigation, Calendar } from "lucide-react";
 import { useAppStore } from "@/store/app-store";
 import type { POI } from "@/types";
+import campusEvents from "@/../public/campus-events.json";
+import type { CampusEvent } from "@/types";
+
+function findUpcomingEventsNear(poi: POI): CampusEvent[] {
+  const today = new Date().toISOString().slice(0, 10);
+  const allEvents = campusEvents as unknown as CampusEvent[];
+  return allEvents
+    .filter((e) => {
+      const endDate = e.endDate || e.date;
+      if (endDate < today) return false;
+      const dist = Math.abs(e.lat - poi.lat) + Math.abs(e.lng - poi.lng);
+      return dist < 0.002;
+    })
+    .slice(0, 2);
+}
 
 export default function POIPopup() {
   const selectedPOI = useAppStore((s) => s.selectedPOI);
   const setSelectedPOI = useAppStore((s) => s.setSelectedPOI);
   const setSelectedDestination = useAppStore((s) => s.setSelectedDestination);
+  const setStreetViewEvent = useAppStore((s) => s.setStreetViewEvent);
+  const setSelectedEvent = useAppStore((s) => s.setSelectedEvent);
+  const setActivePanel = useAppStore((s) => s.setActivePanel);
   const [fadingOutPOI, setFadingOutPOI] = useState<POI | null>(null);
 
   const displayPOI = selectedPOI ?? fadingOutPOI;
   const isVisible = !!selectedPOI;
+
+  const nearbyEvents = useMemo(
+    () => (displayPOI ? findUpcomingEventsNear(displayPOI) : []),
+    [displayPOI]
+  );
 
   const handleClose = useCallback(() => {
     setFadingOutPOI(useAppStore.getState().selectedPOI);
@@ -28,22 +51,49 @@ export default function POIPopup() {
   const handleNavigate = useCallback(() => {
     if (displayPOI) {
       setSelectedDestination(displayPOI);
+      // Open street view at the POI location
+      setStreetViewEvent({
+        id: `poi-${displayPOI.id}`,
+        title: displayPOI.name,
+        date: "",
+        time: "",
+        location: displayPOI.address || displayPOI.name,
+        category: displayPOI.category,
+        description: displayPOI.description,
+        type: "On-Campus",
+        school: "SUSS",
+        lat: displayPOI.lat,
+        lng: displayPOI.lng,
+      } as CampusEvent);
     }
     setSelectedPOI(null);
     setFadingOutPOI(null);
-  }, [displayPOI, setSelectedDestination, setSelectedPOI]);
+  }, [displayPOI, setSelectedDestination, setSelectedPOI, setStreetViewEvent]);
+
+  const handleEventClick = useCallback(
+    (event: CampusEvent) => {
+      setSelectedPOI(null);
+      setFadingOutPOI(null);
+      setSelectedEvent(event);
+      setActivePanel("events");
+    },
+    [setSelectedPOI, setSelectedEvent, setActivePanel]
+  );
 
   if (!displayPOI) return null;
 
   return (
-    <div 
+    <div
       className={`absolute bottom-20 left-1/2 -translate-x-1/2 z-20 transition-all duration-200 ease-in-out ${
-        isVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-4 scale-95 pointer-events-none"
+        isVisible
+          ? "opacity-100 translate-y-0 scale-100"
+          : "opacity-0 translate-y-4 scale-95 pointer-events-none"
       }`}
       onTransitionEnd={handleTransitionEnd}
     >
       <div className="bg-white rounded-xl shadow-lg max-w-sm w-[350px] p-4 relative border border-gray-100">
-        <button type="button"
+        <button
+          type="button"
           onClick={handleClose}
           className="absolute top-3 right-3 text-gray-400 hover:text-gray-600 transition-colors"
           aria-label="Close popup"
@@ -60,7 +110,7 @@ export default function POIPopup() {
         <h3 className="text-lg font-bold text-gray-900 mb-1 pr-6">
           {displayPOI.name}
         </h3>
-        
+
         <p className="text-sm text-gray-600 mb-3 line-clamp-2">
           {displayPOI.description}
         </p>
@@ -68,27 +118,66 @@ export default function POIPopup() {
         <div className="space-y-1.5 mb-4 text-sm text-gray-500">
           {displayPOI.address && (
             <div className="flex items-start gap-2">
-              <MapPin size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+              <MapPin
+                size={16}
+                className="mt-0.5 shrink-0"
+                aria-hidden="true"
+              />
               <span className="line-clamp-1">{displayPOI.address}</span>
             </div>
           )}
-          
+
           {displayPOI.hours && (
             <div className="flex items-start gap-2">
-              <Clock size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+              <Clock
+                size={16}
+                className="mt-0.5 shrink-0"
+                aria-hidden="true"
+              />
               <span className="line-clamp-1">{displayPOI.hours}</span>
             </div>
           )}
 
           {displayPOI.rating && (
             <div className="flex items-center gap-2">
-              <Star size={16} className="text-yellow-500 fill-yellow-500 shrink-0" aria-hidden="true" />
+              <Star
+                size={16}
+                className="text-yellow-500 fill-yellow-500 shrink-0"
+                aria-hidden="true"
+              />
               <span>{displayPOI.rating} / 5.0</span>
             </div>
           )}
         </div>
 
-        <button type="button"
+        {nearbyEvents.length > 0 && (
+          <div className="mb-3 border-t border-gray-100 pt-3">
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2 flex items-center gap-1.5">
+              <Calendar size={12} aria-hidden="true" />
+              Upcoming Events Nearby
+            </p>
+            <div className="space-y-1.5">
+              {nearbyEvents.map((evt) => (
+                <button
+                  key={evt.id}
+                  type="button"
+                  onClick={() => handleEventClick(evt)}
+                  className="w-full text-left flex items-center gap-2 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2 hover:bg-amber-100 transition-colors"
+                >
+                  <span className="text-amber-600 text-xs font-medium shrink-0">
+                    {evt.date}
+                  </span>
+                  <span className="text-xs text-gray-700 truncate">
+                    {evt.title}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <button
+          type="button"
           onClick={handleNavigate}
           className="w-full bg-surface-brand text-surface-brand-foreground rounded-lg px-4 py-2 text-sm font-medium hover:bg-surface-brand/90 transition-colors flex items-center justify-center gap-2"
         >


### PR DESCRIPTION
## Summary
- **Pin → Street View**: Clicking "Navigate here" on a POI popup opens Street View at that location
- **Nearby Events**: POI popup shows upcoming events near the selected pin with clickable links
- **Transparent Sidebar**: Backdrop blur (`bg-background/80 backdrop-blur-xl`) lets the 3D map show through
- **Resizable**: Drag handle between sidebar and map (320px–600px range, desktop only)
- **Minimizable**: Minimize button collapses sidebar; floating "AskSUSSi" button restores it
- **Mobile**: Bottom sheet also transparent with backdrop blur
- **Events scrollable**: `overflow-y-auto` on events tab content

## Test plan
- [ ] Click a POI pin → popup appears → click "Navigate here" → Street View opens at that location
- [ ] POI popup shows "Upcoming Events Nearby" section if events exist near that pin
- [ ] Clicking a nearby event opens the Events panel with that event selected
- [ ] Sidebar is semi-transparent — 3D map visible behind it
- [ ] Drag the resize handle to widen/narrow the sidebar
- [ ] Click minimize (−) button → sidebar collapses → floating "AskSUSSi" button appears
- [ ] Click floating button → sidebar restores
- [ ] Mobile bottom sheet is transparent
- [ ] Events panel scrolls independently
- [ ] `npm run build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)