### PR TITLE
feat: improve fonts and UI for high-res screens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -114,12 +114,12 @@
   --event-external-bg: oklch(0.94 0.06 60);
   --event-external-fg: oklch(0.40 0.12 60);
 
-  /* ── Type Scale ── */
-  --text-hero: clamp(1.875rem, 1.5rem + 1.5vw, 3rem);
-  --text-lg: 1.125rem;
-  --text-base: 0.875rem;
-  --text-sm: 0.75rem;
-  --text-xs: 0.625rem;
+  /* ── Type Scale (hi-res friendly) ── */
+  --text-hero: clamp(2.25rem, 1.8rem + 1.8vw, 3.5rem);
+  --text-lg: 1.25rem;
+  --text-base: 1rem;
+  --text-sm: 0.875rem;
+  --text-xs: 0.75rem;
 
   /* ── Z-Index Scale ──
    * base:       0   — normal flow
@@ -187,11 +187,15 @@
   * {
     @apply border-border outline-ring/50;
   }
-  body {
-    @apply bg-background text-foreground;
-  }
   html {
     @apply font-sans;
+    font-size: clamp(15px, 14px + 0.15vw, 17px);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+  }
+  body {
+    @apply bg-background text-foreground leading-relaxed;
   }
 }
 

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -80,7 +80,7 @@ export default function ChatMessage({
     >
       <div
         className={cn(
-          "max-w-[85%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed",
+          "max-w-[85%] rounded-2xl px-4 py-3 text-[0.9375rem] leading-relaxed",
           role === "user"
             ? "bg-surface-brand text-surface-brand-foreground rounded-br-sm"
             : "bg-secondary text-foreground rounded-bl-sm"

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -126,21 +126,21 @@ export default function ChatPanel() {
         className="flex-1 overflow-y-auto p-4"
       >
         {messages.length === 0 && (
-          <div className="text-center text-sm py-8 px-4">
+          <div className="text-center py-10 px-4">
             <Image
               src="/suss-logo.png"
               alt="SUSS — Singapore University of Social Sciences"
               width={160}
               height={56}
-              className="mx-auto mb-4 h-14 w-auto"
+              className="mx-auto mb-5 h-16 w-auto"
               priority
             />
-            <p className="font-semibold text-foreground">Welcome to AskSUSSi</p>
-            <p className="mt-1 text-muted-foreground">
+            <p className="font-bold text-foreground text-lg">Welcome to AskSUSSi</p>
+            <p className="mt-1.5 text-muted-foreground text-sm">
               Your campus intelligent assistant. Ask me about directions, events,
               or campus services.
             </p>
-            <section aria-label="Suggested questions" className="mt-5 flex flex-wrap justify-center gap-2">
+            <section aria-label="Suggested questions" className="mt-6 flex flex-wrap justify-center gap-2.5">
               {[
                 "Where is the library?",
                 "What events are today?",
@@ -150,7 +150,7 @@ export default function ChatPanel() {
                   type="button"
                   key={q}
                   onClick={() => handleSend(q)}
-                  className="text-xs px-3.5 py-2 rounded-full border border-primary/20 text-primary hover:bg-primary hover:text-primary-foreground transition-colors font-medium"
+                  className="text-sm px-4 py-2.5 rounded-full border border-primary/20 text-primary hover:bg-primary hover:text-primary-foreground transition-colors font-medium"
                 >
                   {q}
                 </button>
@@ -177,7 +177,7 @@ export default function ChatPanel() {
         <div ref={endRef} />
         {isWaiting && (
           <div className="flex justify-start mb-3">
-            <div className="bg-secondary rounded-2xl rounded-bl-sm px-4 py-2.5 text-sm">
+            <div className="bg-secondary rounded-2xl rounded-bl-sm px-4 py-3 text-base">
               <span className="inline-flex gap-1">
                 <span className="animate-bounce">·</span>
                 <span className="animate-bounce" style={{ animationDelay: "0.1s" }}>

--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -41,13 +41,13 @@ export default function EventCard({ event }: EventCardProps) {
       className="w-full text-left p-3 rounded-lg border hover:bg-muted/50 transition-colors flex flex-col gap-2"
     >
       <div className="flex items-start justify-between gap-2 w-full">
-        <h3 className="font-medium text-sm leading-tight">{event.title}</h3>
-        <Badge variant="secondary" className="text-[10px] shrink-0">
+        <h3 className="font-semibold text-[0.9375rem] leading-snug">{event.title}</h3>
+        <Badge variant="secondary" className="text-xs shrink-0">
           {event.category}
         </Badge>
       </div>
 
-      <div className="flex items-center gap-2 text-[11px] text-muted-foreground flex-wrap w-full">
+      <div className="flex items-center gap-2 text-xs text-muted-foreground flex-wrap w-full">
         <span>{dateDisplay}</span>
         <span>·</span>
         <span>{event.time}</span>
@@ -57,21 +57,21 @@ export default function EventCard({ event }: EventCardProps) {
 
       <div className="flex items-center gap-2 w-full">
         {event.type && (
-          <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${TYPE_COLORS[event.type] || "bg-muted text-muted-foreground"}`}>
+          <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${TYPE_COLORS[event.type] || "bg-muted text-muted-foreground"}`}>
             {event.type}
           </span>
         )}
         {event.school && (
-          <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground font-medium">
+          <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground font-medium">
             {event.school}
           </span>
         )}
       </div>
 
-      <p className="text-xs text-muted-foreground line-clamp-2 w-full">{event.description}</p>
+      <p className="text-sm text-muted-foreground line-clamp-2 w-full">{event.description}</p>
 
       {event.longDescription && (
-        <div className="w-full text-xs text-muted-foreground mt-1">
+        <div className="w-full text-sm text-muted-foreground mt-1">
           <div className={isExpanded ? "" : "line-clamp-2"}>
             {event.longDescription}
           </div>
@@ -81,7 +81,7 @@ export default function EventCard({ event }: EventCardProps) {
               e.stopPropagation();
               setIsExpanded(!isExpanded);
             }}
-            className="text-primary hover:underline mt-1 font-medium text-[11px]"
+            className="text-primary hover:underline mt-1 font-medium text-xs"
           >
             {isExpanded ? "Show less" : "Show more"}
           </button>
@@ -89,7 +89,7 @@ export default function EventCard({ event }: EventCardProps) {
       )}
 
       {event.venueAddress && (
-        <div className="flex items-start gap-1.5 text-xs text-muted-foreground mt-1 w-full">
+        <div className="flex items-start gap-1.5 text-sm text-muted-foreground mt-1 w-full">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 24 24"
@@ -113,7 +113,7 @@ export default function EventCard({ event }: EventCardProps) {
           <button
             type="button"
             onClick={handleNavigate}
-            className="flex items-center gap-1.5 bg-primary text-primary-foreground px-3 py-1.5 rounded-md text-xs font-medium hover:opacity-90 transition-opacity"
+            className="flex items-center gap-1.5 bg-primary text-primary-foreground px-3.5 py-2 rounded-lg text-sm font-medium hover:opacity-90 transition-opacity"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -137,7 +137,7 @@ export default function EventCard({ event }: EventCardProps) {
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => e.stopPropagation()}
-            className="text-[10px] text-primary hover:underline ml-auto"
+            className="text-xs text-primary hover:underline ml-auto"
           >
             Join Online →
           </a>

--- a/src/components/events/EventFilter.tsx
+++ b/src/components/events/EventFilter.tsx
@@ -45,7 +45,7 @@ export default function EventFilter({
             type="button"
             onClick={() => onDateChange(p.value)}
             className={cn(
-              "flex-1 rounded-md px-2 py-1 text-xs font-medium transition-colors",
+              "flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
               dateFilter === p.value
                 ? "bg-background text-foreground shadow-sm"
                 : "text-foreground/60 hover:text-foreground"
@@ -56,7 +56,7 @@ export default function EventFilter({
         ))}
       </div>
       <Select value={categoryFilter} onValueChange={(value) => onCategoryChange(value ?? "")}>
-        <SelectTrigger className="text-xs h-8 rounded-md bg-background px-2 w-[160px]">
+        <SelectTrigger className="text-sm h-9 rounded-md bg-background px-3 w-[160px]">
           <SelectValue placeholder="All categories" />
         </SelectTrigger>
         <SelectContent>
@@ -69,7 +69,7 @@ export default function EventFilter({
         </SelectContent>
       </Select>
       <Select value={schoolFilter} onValueChange={(value) => onSchoolChange(value ?? "")}>
-        <SelectTrigger className="text-xs h-8 rounded-md bg-background px-2 w-[120px]">
+        <SelectTrigger className="text-sm h-9 rounded-md bg-background px-3 w-[120px]">
           <SelectValue placeholder="All schools" />
         </SelectTrigger>
         <SelectContent>

--- a/src/components/events/EventsPanel.tsx
+++ b/src/components/events/EventsPanel.tsx
@@ -66,7 +66,7 @@ export default function EventsPanel() {
           />
         ) : (
           <div className="space-y-2">
-            <p className="text-xs text-muted-foreground px-1">{events.length} events</p>
+            <p className="text-sm text-muted-foreground px-1 font-medium">{events.length} events</p>
             {events.map((event) => (
               <EventCard key={event.id} event={event} />
             ))}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -108,7 +108,7 @@ export default function AppShell() {
               priority
             />
             <div className="h-5 w-px bg-white/25" />
-            <span className="text-xs font-semibold tracking-wide opacity-90">
+            <span className="text-sm font-bold tracking-wide opacity-90">
               AskSUSSi
             </span>
           </div>
@@ -217,7 +217,7 @@ export default function AppShell() {
               priority
             />
             <div className="h-5 w-px bg-white/25" />
-            <span className="text-xs font-semibold tracking-wide opacity-90">
+            <span className="text-sm font-bold tracking-wide opacity-90">
               AskSUSSi
             </span>
           </div>

--- a/src/components/layout/HeroIntro.tsx
+++ b/src/components/layout/HeroIntro.tsx
@@ -235,7 +235,7 @@ export default function HeroIntro({ onEnter }: HeroIntroProps) {
       </div>
 
       {/* Bottom label */}
-      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 text-white/25 text-[10px] tracking-[0.2em] uppercase animate-hero-fade-in [animation-delay:1400ms]">
+      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 text-white/30 text-xs tracking-[0.2em] uppercase animate-hero-fade-in [animation-delay:1400ms]">
         SUSS Campus Intelligent Assistant
       </div>
     </header>

--- a/src/components/map/EventPopup.tsx
+++ b/src/components/map/EventPopup.tsx
@@ -41,7 +41,7 @@ export default function EventPopup() {
       }`}
       onTransitionEnd={handleTransitionEnd}
     >
-      <div className="bg-white rounded-xl shadow-lg max-w-sm w-[350px] p-4 relative border border-gray-100">
+      <div className="bg-white rounded-xl shadow-lg max-w-md w-[380px] p-5 relative border border-gray-100">
         <button type="button"
           onClick={handleClose}
           className="absolute top-3 right-3 text-gray-400 hover:text-gray-600 transition-colors"
@@ -66,20 +66,20 @@ export default function EventPopup() {
         </button>
 
         <div className="mb-2">
-          <span className="inline-block bg-secondary text-secondary-foreground text-xs font-semibold px-2.5 py-0.5 rounded-full">
+          <span className="inline-block bg-secondary text-secondary-foreground text-sm font-semibold px-3 py-1 rounded-full">
             {displayEvent.category}
           </span>
         </div>
 
-        <h3 className="text-lg font-bold text-foreground mb-1 pr-6">
+        <h3 className="text-xl font-bold text-foreground mb-1.5 pr-6">
           {displayEvent.title}
         </h3>
-        
-        <p className="text-sm text-muted-foreground mb-3 line-clamp-2">
+
+        <p className="text-[0.9375rem] text-muted-foreground mb-3 line-clamp-2 leading-relaxed">
           {displayEvent.description}
         </p>
 
-        <div className="space-y-1.5 mb-4 text-sm text-muted-foreground">
+        <div className="space-y-2 mb-4 text-[0.9375rem] text-muted-foreground">
           <div className="flex items-start gap-2">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mt-0.5 shrink-0" aria-hidden="true">
               <title>Date</title>
@@ -124,10 +124,10 @@ export default function EventPopup() {
         </div>
 
         <div className="flex gap-2 mb-4">
-          <span className="bg-secondary text-secondary-foreground text-[10px] px-1.5 py-0.5 rounded-full font-medium">
+          <span className="bg-secondary text-secondary-foreground text-xs px-2 py-0.5 rounded-full font-medium">
             {displayEvent.type}
           </span>
-          <span className="bg-muted text-muted-foreground text-[10px] px-1.5 py-0.5 rounded-full font-medium">
+          <span className="bg-muted text-muted-foreground text-xs px-2 py-0.5 rounded-full font-medium">
             {displayEvent.school}
           </span>
         </div>
@@ -138,7 +138,7 @@ export default function EventPopup() {
               href={displayEvent.url} 
               target="_blank" 
               rel="noopener noreferrer"
-              className="text-xs text-primary hover:underline font-medium"
+              className="text-sm text-primary hover:underline font-medium"
             >
               Details →
             </a>
@@ -148,20 +148,20 @@ export default function EventPopup() {
         {displayEvent.type !== "Online" ? (
           <button type="button"
             onClick={handleNavigate}
-            className="w-full bg-primary text-primary-foreground rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary/90 transition-colors flex items-center justify-center gap-2"
+            className="w-full bg-primary text-primary-foreground rounded-lg px-4 py-2.5 text-[0.9375rem] font-semibold hover:bg-primary/90 transition-colors flex items-center justify-center gap-2"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <title>Navigate</title>
               <polygon points="3 11 22 2 13 21 11 13 3 11"/>
             </svg>
             Navigate here
           </button>
         ) : displayEvent.url ? (
-          <a 
+          <a
             href={displayEvent.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="w-full bg-primary text-primary-foreground rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary/90 transition-colors flex items-center justify-center gap-2"
+            className="w-full bg-primary text-primary-foreground rounded-lg px-4 py-2.5 text-[0.9375rem] font-semibold hover:bg-primary/90 transition-colors flex items-center justify-center gap-2"
           >
             Join Online →
           </a>

--- a/src/components/map/POIPopup.tsx
+++ b/src/components/map/POIPopup.tsx
@@ -91,7 +91,7 @@ export default function POIPopup() {
       }`}
       onTransitionEnd={handleTransitionEnd}
     >
-      <div className="bg-white rounded-xl shadow-lg max-w-sm w-[350px] p-4 relative border border-gray-100">
+      <div className="bg-white rounded-xl shadow-lg max-w-md w-[380px] p-5 relative border border-gray-100">
         <button
           type="button"
           onClick={handleClose}
@@ -102,20 +102,20 @@ export default function POIPopup() {
         </button>
 
         <div className="mb-2">
-          <span className="inline-block bg-blue-50 text-surface-brand text-xs font-semibold px-2.5 py-0.5 rounded-full border border-blue-100">
+          <span className="inline-block bg-blue-50 text-surface-brand text-sm font-semibold px-3 py-1 rounded-full border border-blue-100">
             {displayPOI.category}
           </span>
         </div>
 
-        <h3 className="text-lg font-bold text-gray-900 mb-1 pr-6">
+        <h3 className="text-xl font-bold text-gray-900 mb-1.5 pr-6">
           {displayPOI.name}
         </h3>
 
-        <p className="text-sm text-gray-600 mb-3 line-clamp-2">
+        <p className="text-[0.9375rem] text-gray-600 mb-3 line-clamp-2 leading-relaxed">
           {displayPOI.description}
         </p>
 
-        <div className="space-y-1.5 mb-4 text-sm text-gray-500">
+        <div className="space-y-2 mb-4 text-[0.9375rem] text-gray-500">
           {displayPOI.address && (
             <div className="flex items-start gap-2">
               <MapPin
@@ -152,8 +152,8 @@ export default function POIPopup() {
 
         {nearbyEvents.length > 0 && (
           <div className="mb-3 border-t border-gray-100 pt-3">
-            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2 flex items-center gap-1.5">
-              <Calendar size={12} aria-hidden="true" />
+            <p className="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-2 flex items-center gap-1.5">
+              <Calendar size={14} aria-hidden="true" />
               Upcoming Events Nearby
             </p>
             <div className="space-y-1.5">
@@ -162,12 +162,12 @@ export default function POIPopup() {
                   key={evt.id}
                   type="button"
                   onClick={() => handleEventClick(evt)}
-                  className="w-full text-left flex items-center gap-2 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2 hover:bg-amber-100 transition-colors"
+                  className="w-full text-left flex items-center gap-2.5 bg-amber-50 border border-amber-100 rounded-lg px-3.5 py-2.5 hover:bg-amber-100 transition-colors"
                 >
-                  <span className="text-amber-600 text-xs font-medium shrink-0">
+                  <span className="text-amber-600 text-sm font-medium shrink-0">
                     {evt.date}
                   </span>
-                  <span className="text-xs text-gray-700 truncate">
+                  <span className="text-sm text-gray-700 truncate">
                     {evt.title}
                   </span>
                 </button>
@@ -179,7 +179,7 @@ export default function POIPopup() {
         <button
           type="button"
           onClick={handleNavigate}
-          className="w-full bg-surface-brand text-surface-brand-foreground rounded-lg px-4 py-2 text-sm font-medium hover:bg-surface-brand/90 transition-colors flex items-center justify-center gap-2"
+          className="w-full bg-surface-brand text-surface-brand-foreground rounded-lg px-4 py-2.5 text-[0.9375rem] font-semibold hover:bg-surface-brand/90 transition-colors flex items-center justify-center gap-2"
         >
           <Navigation size={16} aria-hidden="true" />
           Navigate here


### PR DESCRIPTION
## Summary
- **Responsive root font-size**: `clamp(15px, 14px + 0.15vw, 17px)` scales smoothly on hi-res displays
- **Type scale bumped**: base 14→16px, sm 12→14px, xs 10→12px, hero enlarged
- **All 10 UI components updated**: ChatMessage, ChatPanel, EventCard, EventFilter, EventsPanel, AppShell, HeroIntro, EventPopup, POIPopup — larger text, buttons, badges, and popup containers
- **Better font rendering**: `-webkit-font-smoothing: antialiased`, `text-rendering: optimizeLegibility`, relaxed line heights

## Test plan
- [ ] Verify text is readable on Retina / 4K displays
- [ ] Check chat bubbles, event cards, popups, and filters for proper sizing
- [ ] Confirm hero intro text scales well on mobile vs desktop
- [ ] Test popup widths don't overflow on smaller viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)