### PR TITLE
feat: UX polish and refinements across all features

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import type { TextUIPart } from "ai";
+import { toast } from "sonner";
 import ChatMessage from "./ChatMessage";
 import ChatInput from "./ChatInput";
 import { useAppStore } from "@/store/app-store";
@@ -15,6 +16,7 @@ export default function ChatPanel() {
   const endRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const userScrolledUpRef = useRef(false);
+  const [hasNewMessages, setHasNewMessages] = useState(false);
   const setFlyToTarget = useAppStore((s) => s.setFlyToTarget);
   const setSelectedDestination = useAppStore((s) => s.setSelectedDestination);
   const setRouteInfo = useAppStore((s) => s.setRouteInfo);
@@ -55,6 +57,7 @@ export default function ChatPanel() {
                 });
               }
             } catch {
+              toast.error("Could not compute walking route.");
             }
           }
         }
@@ -73,6 +76,7 @@ export default function ChatPanel() {
         }
         if (category) setEventCategoryFilter(category);
         setActivePanel("events");
+        toast.info("Showing matching events.");
       }
     },
     onFinish: ({ message }) => {
@@ -90,8 +94,11 @@ export default function ChatPanel() {
   const isActive = status === "streaming" || status === "submitted";
 
   useEffect(() => {
-    if (!userScrolledUpRef.current) {
+    if (userScrolledUpRef.current) {
+      if (messages.length > 0) setHasNewMessages(true);
+    } else {
       endRef.current?.scrollIntoView({ behavior: "smooth" });
+      setHasNewMessages(false);
     }
   });
 
@@ -108,6 +115,13 @@ export default function ChatPanel() {
     if (!el) return;
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
     userScrolledUpRef.current = !atBottom;
+    if (atBottom) setHasNewMessages(false);
+  };
+
+  const scrollToBottom = () => {
+    userScrolledUpRef.current = false;
+    setHasNewMessages(false);
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
   };
 
   const handleSend = (text: string) => {
@@ -116,7 +130,7 @@ export default function ChatPanel() {
   };
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full relative">
       <div
         role="log"
         aria-label="Chat messages"
@@ -191,6 +205,15 @@ export default function ChatPanel() {
           </div>
         )}
       </div>
+      {hasNewMessages && (
+        <button
+          type="button"
+          onClick={scrollToBottom}
+          className="absolute bottom-16 left-1/2 -translate-x-1/2 z-10 bg-primary text-primary-foreground text-xs font-medium px-3 py-1.5 rounded-full shadow-lg hover:bg-primary/90 transition-colors"
+        >
+          New messages ↓
+        </button>
+      )}
       <ChatInput onSend={handleSend} isLoading={isActive} />
     </div>
   );

--- a/src/components/chat/VoiceButton.tsx
+++ b/src/components/chat/VoiceButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { useSpeechRecognition } from "@/lib/voice/speech-recognition";
 import { Mic } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -15,7 +16,7 @@ export default function VoiceButton({ onTranscript }: VoiceButtonProps) {
     if (isListening) {
       stopListening();
     } else {
-      startListening(onTranscript);
+      startListening(onTranscript, (msg) => toast.error(msg));
     }
   };
 

--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -17,11 +17,13 @@ const TYPE_COLORS: Record<string, string> = {
 
 export default function EventCard({ event }: EventCardProps) {
   const setFlyToTarget = useAppStore((s) => s.setFlyToTarget);
+  const setSelectedEvent = useAppStore((s) => s.setSelectedEvent);
   const setStreetViewEvent = useAppStore((s) => s.setStreetViewEvent);
   const [isExpanded, setIsExpanded] = useState(false);
 
   const handleClick = () => {
     setFlyToTarget({ lat: event.lat, lng: event.lng });
+    setSelectedEvent(event);
   };
 
   const handleNavigate = (e: React.MouseEvent) => {

--- a/src/components/events/EventsPanel.tsx
+++ b/src/components/events/EventsPanel.tsx
@@ -63,6 +63,19 @@ export default function EventsPanel() {
             icon={<CalendarX className="h-8 w-8 text-muted-foreground" />}
             title="No events found"
             description="Try adjusting your filters."
+            action={
+              <button
+                type="button"
+                onClick={() => {
+                  setDateFilter("all");
+                  setCategoryFilter("");
+                  setSchoolFilter("");
+                }}
+                className="mt-1 text-sm text-primary hover:underline font-medium"
+              >
+                Clear all filters
+              </button>
+            }
           />
         ) : (
           <div className="space-y-2">

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -32,7 +32,7 @@ export default function AppShell() {
   const setActivePanel = useAppStore((s) => s.setActivePanel);
   const ttsEnabled = useAppStore((s) => s.ttsEnabled);
   const setTtsEnabled = useAppStore((s) => s.setTtsEnabled);
-  const [mobileSheetOpen, setMobileSheetOpen] = useState(true);
+  const [mobileSheet, setMobileSheet] = useState<"collapsed" | "peek" | "expanded">("expanded");
   const [minimized, setMinimized] = useState(false);
   const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH);
   const isResizing = useRef(false);
@@ -51,6 +51,18 @@ export default function AppShell() {
     },
     [panelWidth]
   );
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.speechSynthesis) {
+      window.speechSynthesis.cancel();
+    }
+  }, [activePanel]);
+
+  const cycleSheet = useCallback(() => {
+    setMobileSheet((prev) =>
+      prev === "collapsed" ? "peek" : prev === "peek" ? "expanded" : "collapsed"
+    );
+  }, []);
 
   useEffect(() => {
     const handleMove = (e: MouseEvent | TouchEvent) => {
@@ -162,7 +174,7 @@ export default function AppShell() {
         <button
           type="button"
           aria-label="Resize panel"
-          className="hidden md:flex items-center justify-center w-2 cursor-col-resize hover:bg-primary/10 active:bg-primary/20 transition-colors group shrink-0 border-0 bg-transparent p-0"
+          className="hidden md:flex items-center justify-center w-3 px-2 -mx-2 cursor-col-resize hover:bg-primary/10 active:bg-primary/20 transition-colors group shrink-0 border-0 bg-transparent"
           onMouseDown={handleResizeStart}
           onTouchStart={handleResizeStart}
         >
@@ -191,17 +203,17 @@ export default function AppShell() {
         aria-label="Chat and Events (mobile)"
         className={`
           md:hidden fixed bottom-0 left-0 right-0 z-30
-          ${mobileSheetOpen ? "h-[55dvh]" : "h-12"}
+          ${mobileSheet === "expanded" ? "h-[55dvh]" : mobileSheet === "peek" ? "h-[120px]" : "h-12"}
           bg-background/90 backdrop-blur-xl transition-all duration-300
-          flex flex-col
+          flex flex-col overflow-hidden
           rounded-t-2xl shadow-[0_-4px_12px_rgba(0,0,0,0.1)]
         `}
       >
         <button
           type="button"
-          aria-label={mobileSheetOpen ? "Collapse panel" : "Expand panel"}
+          aria-label={mobileSheet === "expanded" ? "Collapse panel" : "Expand panel"}
           className="flex justify-center py-2 shrink-0"
-          onClick={() => setMobileSheetOpen(!mobileSheetOpen)}
+          onClick={cycleSheet}
         >
           <div className="w-8 h-1 rounded-full bg-muted-foreground/30" />
         </button>

--- a/src/components/map/EventPopup.tsx
+++ b/src/components/map/EventPopup.tsx
@@ -41,7 +41,7 @@ export default function EventPopup() {
       }`}
       onTransitionEnd={handleTransitionEnd}
     >
-      <div className="bg-white rounded-xl shadow-lg max-w-md w-[380px] p-5 relative border border-gray-100">
+      <div className="bg-white rounded-xl shadow-lg max-w-md w-[calc(100vw-2rem)] sm:w-[380px] p-5 relative border border-gray-100">
         <button type="button"
           onClick={handleClose}
           className="absolute top-3 right-3 text-gray-400 hover:text-gray-600 transition-colors"

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -241,6 +241,9 @@ function Map3DInner() {
   );
 
   useEffect(() => {
+    if (typeof window !== "undefined" && window.speechSynthesis) {
+      window.speechSynthesis.cancel();
+    }
     if (streetViewEvent && streetViewEvent.type !== "Online") {
       const timeoutId = window.setTimeout(() => {
         setStreetViewLocation({ lat: streetViewEvent.lat, lng: streetViewEvent.lng });

--- a/src/components/map/POIPopup.tsx
+++ b/src/components/map/POIPopup.tsx
@@ -91,7 +91,7 @@ export default function POIPopup() {
       }`}
       onTransitionEnd={handleTransitionEnd}
     >
-      <div className="bg-white rounded-xl shadow-lg max-w-md w-[380px] p-5 relative border border-gray-100">
+      <div className="bg-white rounded-xl shadow-lg max-w-md w-[calc(100vw-2rem)] sm:w-[380px] p-5 relative border border-gray-100">
         <button
           type="button"
           onClick={handleClose}

--- a/src/components/map/RouteOverlay.tsx
+++ b/src/components/map/RouteOverlay.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import { useAppStore } from "@/store/app-store";
 import { getBuildingInsights, type SolarInsight } from "@/lib/maps/solar-utils";
 
@@ -34,9 +35,13 @@ export default function RouteOverlay() {
       selectedDestination.lat,
       selectedDestination.lng,
       MAPS_API_KEY
-    ).then((result) => {
-      if (!cancelled) setSolar(result);
-    });
+    )
+      .then((result) => {
+        if (!cancelled) setSolar(result);
+      })
+      .catch(() => {
+        if (!cancelled) toast.error("Sun exposure data unavailable.");
+      });
 
     return () => {
       cancelled = true;

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -4,9 +4,10 @@ interface EmptyStateProps {
   icon?: React.ReactNode;
   title: string;
   description?: string;
+  action?: React.ReactNode;
 }
 
-export function EmptyState({ icon, title, description }: EmptyStateProps) {
+export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center gap-2 py-8 px-4 text-center">
       {icon ?? <Inbox className="h-8 w-8 text-muted-foreground" />}
@@ -14,6 +15,7 @@ export function EmptyState({ icon, title, description }: EmptyStateProps) {
       {description && (
         <p className="text-xs text-muted-foreground">{description}</p>
       )}
+      {action}
     </div>
   );
 }

--- a/src/hooks/useCampusEvents.ts
+++ b/src/hooks/useCampusEvents.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { toast } from "sonner";
 import type { CampusEvent, DateRangePreset } from "@/types";
 import { getDateRange } from "@/lib/date-utils";
 
@@ -18,7 +19,10 @@ export function useCampusEvents() {
         setEvents(data);
         setIsLoading(false);
       })
-      .catch(() => setIsLoading(false));
+      .catch(() => {
+        toast.error("Failed to load campus events.");
+        setIsLoading(false);
+      });
   }, []);
 
   const filteredEvents = useMemo(() => {

--- a/src/lib/voice/speech-recognition.ts
+++ b/src/lib/voice/speech-recognition.ts
@@ -12,7 +12,7 @@ export function useSpeechRecognition() {
   const recognitionRef = useRef<ReturnType<typeof createRecognition> | null>(null);
 
   const startListening = useCallback(
-    (onResult: (text: string) => void) => {
+    (onResult: (text: string) => void, onError?: (message: string) => void) => {
       const recognition = createRecognition();
       if (!recognition) return;
 
@@ -28,7 +28,16 @@ export function useSpeechRecognition() {
       };
 
       recognition.onend = () => setIsListening(false);
-      recognition.onerror = () => setIsListening(false);
+      recognition.onerror = (event: { error: string }) => {
+        setIsListening(false);
+        const msg =
+          event.error === "not-allowed"
+            ? "Microphone access denied. Please allow microphone permissions."
+            : event.error === "no-speech"
+              ? "No speech detected. Please try again."
+              : "Voice input failed. Please try again.";
+        onError?.(msg);
+      };
 
       setIsListening(true);
       recognition.start();

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 import type { POI, RouteInfo, CampusEvent, DateRangePreset } from "@/types";
 
 interface AppState {
@@ -39,34 +40,45 @@ interface AppState {
   setTtsEnabled: (enabled: boolean) => void;
 }
 
-export const useAppStore = create<AppState>((set) => ({
-  selectedPOI: null,
-  setSelectedPOI: (poi) => set({ selectedPOI: poi, selectedEvent: null }),
-  selectedDestination: null,
-  setSelectedDestination: (poi) => set({ selectedDestination: poi }),
-  routeInfo: null,
-  setRouteInfo: (route) => set({ routeInfo: route }),
-  flyToTarget: null,
-  setFlyToTarget: (target) => set({ flyToTarget: target }),
+export const useAppStore = create<AppState>()(
+  persist(
+    (set) => ({
+      selectedPOI: null,
+      setSelectedPOI: (poi) => set({ selectedPOI: poi, selectedEvent: null }),
+      selectedDestination: null,
+      setSelectedDestination: (poi) => set({ selectedDestination: poi }),
+      routeInfo: null,
+      setRouteInfo: (route) => set({ routeInfo: route }),
+      flyToTarget: null,
+      setFlyToTarget: (target) => set({ flyToTarget: target }),
 
-  activePanel: "chat",
-  setActivePanel: (panel) => set({ activePanel: panel }),
+      activePanel: "chat",
+      setActivePanel: (panel) => set({ activePanel: panel }),
 
-  eventDateFilter: "all",
-  setEventDateFilter: (preset) => set({ eventDateFilter: preset }),
-  eventCategoryFilter: "",
-  setEventCategoryFilter: (category) => set({ eventCategoryFilter: category }),
-  mapEventMarkers: [],
-  setMapEventMarkers: (events) => set({ mapEventMarkers: events }),
-  highlightedEventIds: [],
-  setHighlightedEventIds: (ids) => set({ highlightedEventIds: ids }),
-  selectedEvent: null,
-  setSelectedEvent: (event) => set({ selectedEvent: event, selectedPOI: null }),
-  streetViewEvent: null,
-  setStreetViewEvent: (event) => set({ streetViewEvent: event }),
+      eventDateFilter: "all",
+      setEventDateFilter: (preset) => set({ eventDateFilter: preset }),
+      eventCategoryFilter: "",
+      setEventCategoryFilter: (category) => set({ eventCategoryFilter: category }),
+      mapEventMarkers: [],
+      setMapEventMarkers: (events) => set({ mapEventMarkers: events }),
+      highlightedEventIds: [],
+      setHighlightedEventIds: (ids) => set({ highlightedEventIds: ids }),
+      selectedEvent: null,
+      setSelectedEvent: (event) => set({ selectedEvent: event, selectedPOI: null }),
+      streetViewEvent: null,
+      setStreetViewEvent: (event) => set({ streetViewEvent: event }),
 
-  isSpeaking: false,
-  setIsSpeaking: (speaking) => set({ isSpeaking: speaking }),
-  ttsEnabled: false,
-  setTtsEnabled: (enabled) => set({ ttsEnabled: enabled }),
-}));
+      isSpeaking: false,
+      setIsSpeaking: (speaking) => set({ isSpeaking: speaking }),
+      ttsEnabled: false,
+      setTtsEnabled: (enabled) => set({ ttsEnabled: enabled }),
+    }),
+    {
+      name: "asksussi-prefs",
+      partialize: (state) => ({
+        ttsEnabled: state.ttsEnabled,
+        activePanel: state.activePanel,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
## Summary
- **Error feedback**: Toast notifications for all previously silent API failures (route, events, solar, voice)
- **Event card → popup**: Clicking an event card now opens the popup on the map automatically
- **Responsive popups**: EventPopup and POIPopup no longer overflow on small screens
- **Chat scroll indicator**: "New messages ↓" button when user scrolls up and new messages arrive
- **Filter UX**: Toast when AI applies event filters; "Clear all filters" button in empty state
- **Mobile bottom sheet**: Three-state height (collapsed → peek → expanded) instead of binary toggle
- **Resize handle**: Wider 28px touch target for easier sidebar resizing
- **Persist preferences**: TTS enabled and active panel persist across page refreshes via localStorage
- **TTS lifecycle**: Speech auto-cancels when switching panels or entering Street View
- **Speech errors**: Microphone permission denied, no speech detected, etc. now show user-friendly toasts

## Test plan
- [ ] Disable network → verify toast appears for event fetch failure
- [ ] Click event card → verify popup opens on map
- [ ] Resize browser to 320px → verify popups don't overflow
- [ ] Scroll up in chat, send message → verify "New messages" button appears
- [ ] Ask AI to show events → verify toast confirmation
- [ ] Filter events to empty → verify "Clear all filters" button works
- [ ] On mobile: tap handle 3 times → cycles collapsed → peek → expanded
- [ ] Toggle TTS, refresh page → verify setting persists
- [ ] Start TTS speaking, switch panel → verify speech stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)