### PR TITLE
feat: complete markdown rendering in chat

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -20,40 +20,84 @@ const MemoizedMarkdown = memo(function MemoizedMarkdown({
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
       components={{
+        h1: ({ children }) => (
+          <h1 className="text-lg font-bold mb-2 mt-3 first:mt-0">{children}</h1>
+        ),
+        h2: ({ children }) => (
+          <h2 className="text-base font-bold mb-1.5 mt-2.5 first:mt-0">{children}</h2>
+        ),
+        h3: ({ children }) => (
+          <h3 className="text-[0.9375rem] font-semibold mb-1 mt-2 first:mt-0">{children}</h3>
+        ),
+        h4: ({ children }) => (
+          <h4 className="text-sm font-semibold mb-1 mt-2 first:mt-0">{children}</h4>
+        ),
         p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
         ul: ({ children }) => (
-          <ul className="list-disc pl-4 mb-2">{children}</ul>
+          <ul className="list-disc pl-4 mb-2 space-y-0.5">{children}</ul>
         ),
         ol: ({ children }) => (
-          <ol className="list-decimal pl-4 mb-2">{children}</ol>
+          <ol className="list-decimal pl-4 mb-2 space-y-0.5">{children}</ol>
         ),
-        li: ({ children }) => <li className="mb-0.5">{children}</li>,
+        li: ({ children }) => <li className="pl-0.5">{children}</li>,
         strong: ({ children }) => (
-          <strong className="font-semibold">{children}</strong>
+          <strong className="font-bold">{children}</strong>
+        ),
+        em: ({ children }) => (
+          <em className="italic">{children}</em>
         ),
         a: ({ href, children }) => (
           <a
             href={href}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-primary underline hover:text-accent"
+            className="text-primary underline underline-offset-2 hover:text-accent transition-colors"
           >
             {children}
           </a>
+        ),
+        blockquote: ({ children }) => (
+          <blockquote className="border-l-3 border-primary/30 pl-3 my-2 text-muted-foreground italic">
+            {children}
+          </blockquote>
+        ),
+        hr: () => (
+          <hr className="my-3 border-t border-foreground/10" />
+        ),
+        del: ({ children }) => (
+          <del className="line-through opacity-60">{children}</del>
+        ),
+        table: ({ children }) => (
+          <div className="my-2 overflow-x-auto rounded-lg border border-foreground/10">
+            <table className="w-full text-sm">{children}</table>
+          </div>
+        ),
+        thead: ({ children }) => (
+          <thead className="bg-foreground/5 text-left">{children}</thead>
+        ),
+        tbody: ({ children }) => <tbody>{children}</tbody>,
+        tr: ({ children }) => (
+          <tr className="border-b border-foreground/5 last:border-0">{children}</tr>
+        ),
+        th: ({ children }) => (
+          <th className="px-3 py-1.5 font-semibold text-xs uppercase tracking-wide">{children}</th>
+        ),
+        td: ({ children }) => (
+          <td className="px-3 py-1.5">{children}</td>
         ),
         code: ({ children, className }) => {
           const isBlock = className?.includes("language-");
           return isBlock ? (
             <code
               className={cn(
-                "block bg-black/5 rounded p-2 text-xs overflow-x-auto my-2 font-mono",
+                "block bg-foreground/5 rounded-lg p-3 text-xs overflow-x-auto my-2 font-mono leading-relaxed",
                 className
               )}
             >
               {children}
             </code>
           ) : (
-            <code className="bg-black/10 rounded px-1 py-0.5 text-xs font-mono">
+            <code className="bg-foreground/10 rounded px-1.5 py-0.5 text-[0.8em] font-mono">
               {children}
             </code>
           );

--- a/src/lib/ai/system-prompt.ts
+++ b/src/lib/ai/system-prompt.ts
@@ -7,6 +7,7 @@ You have access to these tools:
 
 Guidelines:
 - Be friendly, concise, and helpful
+- Use markdown formatting: **bold** for emphasis, headings for sections, bullet lists for multiple items, tables when comparing options (e.g. venues, schedules)
 - When a student asks about a location, use navigate_to to show it on the map
 - When asked about events or activities, use show_events to display relevant events. Events include venue addresses and detailed descriptions when available.
 - For general campus questions or when listing multiple venues, use campus_info


### PR DESCRIPTION
## Summary
- **Headings** (h1-h4): Proper font sizes and weights with spacing
- **Tables**: Bordered, padded cells with header styling — supports remark-gfm tables
- **Blockquotes**: Left border accent with italic muted text
- **Horizontal rules**: Subtle divider styling
- **Strikethrough**: Styled with reduced opacity
- **Code blocks**: Improved with semantic `foreground/5` background (works in light/dark)
- **Inline code**: Better padding and relative font sizing
- **System prompt**: AI now encouraged to use markdown formatting

## Test plan
- [ ] Ask AI "compare the canteen and Starbucks" → verify table renders with borders
- [ ] Ask AI for a detailed answer → verify headings, bold, lists render
- [ ] Send code-related question → verify code blocks render with monospace
- [ ] Verify streaming still works smoothly with markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)