### PR TITLE
chore: switch to gemini-3.1-flash-lite-preview

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -7,7 +7,7 @@ export async function POST(req: Request) {
   const { messages } = await req.json();
 
   const result = streamText({
-    model: google("gemini-2.5-flash"),
+    model: google("gemini-3.1-flash-lite-preview"),
     system: SYSTEM_PROMPT,
     messages,
     tools,


### PR DESCRIPTION
## Summary
- Switch from `gemini-2.5-flash` to `gemini-3.1-flash-lite-preview`
- This model properly supports multi-step tool calling — generates follow-up text after tool execution instead of stopping at `finishReason: "tool-calls"`
- Verified available via API and tested with our tool schemas

## Test plan
- [ ] Ask "Where is the library?" — should use navigate_to tool AND generate text response
- [ ] Ask "What events are today?" — should use show_events tool AND generate text response
- [ ] General questions still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)