### PR TITLE
fix: enable standalone output for Railway deployment

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Add `output: "standalone"` to next.config.ts
- Railway requires standalone mode to properly build and run Next.js apps
- Without this, `railway up` uploads code but the deployment doesn't produce a functional server

## Test plan
- [ ] Verify Railway deployment completes and app is accessible
- [ ] Chat API responds at `/api/chat`
- [ ] Events API responds at `/api/events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)