### PR TITLE
fix: add error handling and visibility to chat

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -63,7 +63,11 @@ export default function ChatPanel() {
   const ttsEnabled = useAppStore((s) => s.ttsEnabled);
   const { speak } = useSpeechSynthesis();
 
-  const { messages, sendMessage, status } = useChat({
+  const { messages, sendMessage, status, error } = useChat({
+    onError: (err) => {
+      console.error("[AskSUSSi chat error]", err);
+      toast.error(err.message || "Chat request failed.");
+    },
     onFinish: ({ message }) => {
       if (ttsEnabled && message.role === "assistant") {
         const { text } = extractMessageContent(message.parts ?? []);
@@ -226,6 +230,12 @@ export default function ChatPanel() {
             />
           );
         })}
+        {error && (
+          <div className="mx-2 mb-3 p-3 rounded-lg bg-destructive/10 text-destructive text-sm">
+            <p className="font-medium">Chat error</p>
+            <p className="mt-1 opacity-80">{error.message}</p>
+          </div>
+        )}
         <div ref={endRef} />
         {isWaiting && (
           <div className="flex justify-start mb-3">


### PR DESCRIPTION
## Summary
- Add `onError` callback to `useChat` that shows toast notification on chat failures
- Add inline error display in chat panel so errors are visible to the user
- Expose `error` state from `useChat` hook

## Test plan
- [ ] If chat API fails, error message should appear as toast and inline
- [ ] Normal chat flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)