### PR TITLE
feat(chat): rich tool result cards, thinking indicator, and retry

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import Image from "next/image";
+import { AlertCircle, RotateCcw } from "lucide-react";
 import type { TextUIPart, DynamicToolUIPart } from "ai";
 import { toast } from "sonner";
 import ChatMessage from "./ChatMessage";
 import ChatInput from "./ChatInput";
+import ToolResultCard from "./ToolResultCard";
+import { Button } from "@/components/ui/button";
 import { useAppStore } from "@/store/app-store";
 import { useSpeechSynthesis } from "@/lib/voice/speech-synthesis";
 import { findPOI } from "@/lib/maps/campus-pois";
@@ -16,33 +19,70 @@ function isToolPart(p: { type: string }): p is DynamicToolUIPart {
   return p.type === "dynamic-tool" || p.type.startsWith("tool-");
 }
 
-function extractMessageContent(parts: Array<{ type: string; [key: string]: unknown }>): {
+function extractTextContent(parts: Array<{ type: string; [key: string]: unknown }>): {
   text: string;
   isStreaming: boolean;
 } {
-  // First try text parts
   const textParts = parts.filter(
     (p): p is TextUIPart => p.type === "text"
   );
-  if (textParts.length > 0) {
-    return {
-      text: textParts.map((p) => p.text).join(""),
-      isStreaming: textParts.some((p) => p.state === "streaming"),
-    };
-  }
+  if (textParts.length === 0) return { text: "", isStreaming: false };
+  return {
+    text: textParts.map((p) => p.text).join(""),
+    isStreaming: textParts.some((p) => p.state === "streaming"),
+  };
+}
 
-  // Fall back to tool output messages (when Gemini stops after tool call)
-  const toolParts = parts.filter(isToolPart);
-  for (const tp of toolParts) {
-    if (tp.state === "output-available") {
-      const output = tp.output as Record<string, unknown> | undefined;
-      if (output?.message) {
-        return { text: output.message as string, isStreaming: false };
-      }
+function renderAssistantParts(
+  parts: Array<{ type: string; [key: string]: unknown }>,
+  messageId: string
+): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let textAccumulator: TextUIPart[] = [];
+
+  const flushText = () => {
+    if (textAccumulator.length === 0) return;
+    const text = textAccumulator.map((p) => p.text).join("");
+    const isStreaming = textAccumulator.some((p) => p.state === "streaming");
+    if (text) {
+      nodes.push(
+        <ChatMessage
+          key={`${messageId}-text-${nodes.length}`}
+          role={"assistant" as const}
+          content={text}
+          isStreaming={isStreaming}
+        />
+      );
+    }
+    textAccumulator = [];
+  };
+
+  for (const part of parts) {
+    if (part.type === "text") {
+      textAccumulator.push(part as TextUIPart);
+      continue;
+    }
+
+    if (isToolPart(part)) {
+      flushText();
+      const tp = part as DynamicToolUIPart;
+      const output = (tp.output ?? {}) as Record<string, unknown>;
+      nodes.push(
+        <div key={`${messageId}-tool-${tp.toolCallId}`} className="flex justify-start mb-3">
+          <div className="max-w-[85%]">
+            <ToolResultCard
+              toolName={tp.toolName}
+              output={output}
+              state={tp.state}
+            />
+          </div>
+        </div>
+      );
     }
   }
 
-  return { text: "", isStreaming: false };
+  flushText();
+  return nodes;
 }
 
 export default function ChatPanel() {
@@ -50,6 +90,7 @@ export default function ChatPanel() {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const userScrolledUpRef = useRef(false);
   const [hasNewMessages, setHasNewMessages] = useState(false);
+  const [lastFailedInput, setLastFailedInput] = useState<string | null>(null);
   const processedToolsRef = useRef<Set<string>>(new Set());
   const setFlyToTarget = useAppStore((s) => s.setFlyToTarget);
   const setSelectedDestination = useAppStore((s) => s.setSelectedDestination);
@@ -66,17 +107,16 @@ export default function ChatPanel() {
   const { messages, sendMessage, status, error } = useChat({
     onError: (err) => {
       console.error("[AskSUSSi chat error]", err);
-      toast.error(err.message || "Chat request failed.");
     },
     onFinish: ({ message }) => {
+      setLastFailedInput(null);
       if (ttsEnabled && message.role === "assistant") {
-        const { text } = extractMessageContent(message.parts ?? []);
+        const { text } = extractTextContent(message.parts ?? []);
         if (text) speak(text);
       }
     },
   });
 
-  // Process tool results from messages for UI side effects
   useEffect(() => {
     for (const msg of messages) {
       if (msg.role !== "assistant") continue;
@@ -93,28 +133,40 @@ export default function ChatPanel() {
         if (!output) continue;
 
         if (tp.toolName === "navigate_to" && output.success && output.poi) {
-          const poi = output.poi as { lat: number; lng: number; name: string; id: string; address?: string; category: string; description: string };
+          const poi = output.poi as {
+            lat: number;
+            lng: number;
+            name: string;
+            id: string;
+            address?: string;
+            category: string;
+            description: string;
+          };
           const localPoi = findPOI(poi.name) ?? poi;
-          setSelectedDestination(localPoi as ReturnType<typeof findPOI> & object);
+          setSelectedDestination(
+            localPoi as ReturnType<typeof findPOI> & object
+          );
           setFlyToTarget({ lat: poi.lat, lng: poi.lng });
 
           const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || "";
           if (apiKey) {
-            import("@/lib/maps/route-utils").then(({ computeWalkingRoute }) =>
-              computeWalkingRoute(
-                { lat: 1.3299, lng: 103.7764 },
-                { lat: poi.lat, lng: poi.lng },
-                apiKey
-              ).then((route) => {
-                if (route) {
-                  setRouteInfo({
-                    polyline: route.polyline,
-                    distanceMeters: route.distanceMeters,
-                    duration: route.durationText,
-                  });
-                }
-              })
-            ).catch(() => toast.error("Could not compute walking route."));
+            import("@/lib/maps/route-utils")
+              .then(({ computeWalkingRoute }) =>
+                computeWalkingRoute(
+                  { lat: 1.3299, lng: 103.7764 },
+                  { lat: poi.lat, lng: poi.lng },
+                  apiKey
+                ).then((route) => {
+                  if (route) {
+                    setRouteInfo({
+                      polyline: route.polyline,
+                      distanceMeters: route.distanceMeters,
+                      duration: route.durationText,
+                    });
+                  }
+                })
+              )
+              .catch(() => toast.error("Could not compute walking route."));
           }
         }
 
@@ -134,10 +186,28 @@ export default function ChatPanel() {
         }
       }
     }
-  }, [messages, setFlyToTarget, setSelectedDestination, setRouteInfo, setActivePanel, setEventDateFilter, setEventCategoryFilter]);
+  }, [
+    messages,
+    setFlyToTarget,
+    setSelectedDestination,
+    setRouteInfo,
+    setActivePanel,
+    setEventDateFilter,
+    setEventCategoryFilter,
+  ]);
 
   const isWaiting = status === "submitted";
-  const isActive = status === "streaming" || status === "submitted";
+  const isStreaming = status === "streaming";
+  const isActive = isStreaming || isWaiting;
+
+  const hasToolInProgress = isActive && messages.some((msg) => {
+    if (msg.role !== "assistant") return false;
+    return (msg.parts ?? []).some((p) => {
+      if (!isToolPart(p)) return false;
+      const state = (p as DynamicToolUIPart).state;
+      return state === "input-streaming" || state === "input-available";
+    });
+  });
 
   useEffect(() => {
     if (userScrolledUpRef.current) {
@@ -171,8 +241,14 @@ export default function ChatPanel() {
   };
 
   const handleSend = (text: string) => {
+    setLastFailedInput(text);
     userScrolledUpRef.current = false;
     sendMessage({ text });
+  };
+
+  const handleRetry = () => {
+    if (!lastFailedInput) return;
+    handleSend(lastFailedInput);
   };
 
   return (
@@ -195,12 +271,17 @@ export default function ChatPanel() {
               className="mx-auto mb-5 h-16 w-auto"
               priority
             />
-            <p className="font-bold text-foreground text-lg">Welcome to AskSUSSi</p>
+            <p className="font-bold text-foreground text-lg">
+              Welcome to AskSUSSi
+            </p>
             <p className="mt-1.5 text-muted-foreground text-sm">
               Your campus intelligent assistant. Ask me about directions, events,
               or campus services.
             </p>
-            <section aria-label="Suggested questions" className="mt-6 flex flex-wrap justify-center gap-2.5">
+            <section
+              aria-label="Suggested questions"
+              className="mt-6 flex flex-wrap justify-center gap-2.5"
+            >
               {[
                 "Where is the library?",
                 "What events are today?",
@@ -218,50 +299,92 @@ export default function ChatPanel() {
             </section>
           </div>
         )}
+
         {messages.map((msg) => {
-          const { text, isStreaming } = extractMessageContent(msg.parts ?? []);
-          if (!text) return null;
-          return (
-            <ChatMessage
-              key={msg.id}
-              role={msg.role as "user" | "assistant"}
-              content={text}
-              isStreaming={isStreaming}
-            />
-          );
+          if (msg.role === "user") {
+            const { text } = extractTextContent(msg.parts ?? []);
+            if (!text) return null;
+            return (
+              <ChatMessage key={msg.id} role={"user" as const} content={text} />
+            );
+          }
+
+          const parts = msg.parts ?? [];
+          const rendered = renderAssistantParts(parts, msg.id);
+          if (rendered.length === 0) return null;
+          return <div key={msg.id}>{rendered}</div>;
         })}
+
         {error && (
-          <div className="mx-2 mb-3 p-3 rounded-lg bg-destructive/10 text-destructive text-sm">
-            <p className="font-medium">Chat error</p>
-            <p className="mt-1 opacity-80">{error.message}</p>
+          <div className="mx-2 mb-3 p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-sm">
+            <div className="flex items-start gap-2">
+              <AlertCircle className="w-4 h-4 text-destructive shrink-0 mt-0.5" />
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-destructive">
+                  Something went wrong
+                </p>
+                <p className="mt-1 text-destructive/80">{error.message}</p>
+              </div>
+            </div>
+            {lastFailedInput && (
+              <div className="mt-2 flex justify-end">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleRetry}
+                  disabled={isActive}
+                  className="text-destructive border-destructive/30 hover:bg-destructive/10"
+                >
+                  <RotateCcw className="w-3.5 h-3.5 mr-1.5" />
+                  Retry
+                </Button>
+              </div>
+            )}
           </div>
         )}
+
         <div ref={endRef} />
-        {isWaiting && (
+
+        {(isWaiting || hasToolInProgress) && (
           <div className="flex justify-start mb-3">
             <div className="bg-secondary rounded-2xl rounded-bl-sm px-4 py-3 text-base">
-              <span className="inline-flex gap-1">
-                <span className="animate-bounce">·</span>
-                <span className="animate-bounce" style={{ animationDelay: "0.1s" }}>
-                  ·
+              <span className="inline-flex items-center gap-2">
+                <span className="inline-flex gap-1">
+                  <span className="animate-bounce">&middot;</span>
+                  <span
+                    className="animate-bounce"
+                    style={{ animationDelay: "0.1s" }}
+                  >
+                    &middot;
+                  </span>
+                  <span
+                    className="animate-bounce"
+                    style={{ animationDelay: "0.2s" }}
+                  >
+                    &middot;
+                  </span>
                 </span>
-                <span className="animate-bounce" style={{ animationDelay: "0.2s" }}>
-                  ·
-                </span>
+                {hasToolInProgress && (
+                  <span className="text-xs text-muted-foreground italic">
+                    Thinking...
+                  </span>
+                )}
               </span>
             </div>
           </div>
         )}
       </div>
+
       {hasNewMessages && (
         <button
           type="button"
           onClick={scrollToBottom}
           className="absolute bottom-16 left-1/2 -translate-x-1/2 z-10 bg-primary text-primary-foreground text-xs font-medium px-3 py-1.5 rounded-full shadow-lg hover:bg-primary/90 transition-colors"
         >
-          New messages ↓
+          New messages &darr;
         </button>
       )}
+
       <ChatInput onSend={handleSend} isLoading={isActive} />
     </div>
   );

--- a/src/components/chat/ToolResultCard.tsx
+++ b/src/components/chat/ToolResultCard.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { memo } from "react";
+import { MapPin, Calendar, Info, Star, Clock, Navigation } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { POI, CampusEvent } from "@/types";
+
+interface NavigateOutput {
+  success: boolean;
+  poi?: POI;
+  message: string;
+}
+
+interface ShowEventsOutput {
+  success: boolean;
+  events: CampusEvent[];
+  filters: { date?: string; category?: string; range?: string };
+  message: string;
+}
+
+interface CampusInfoOutput {
+  success: boolean;
+  query: string;
+  answer: string;
+  venues?: POI[];
+}
+
+function LocationCard({ output }: { output: NavigateOutput }) {
+  const poi = output.poi;
+  if (!poi) {
+    return (
+      <Card size="sm" className="bg-destructive/5 ring-destructive/20">
+        <CardContent className="flex items-start gap-2.5">
+          <MapPin className="w-4 h-4 text-destructive shrink-0 mt-0.5" />
+          <p className="text-sm text-destructive">{output.message}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card size="sm" className="bg-surface-brand/5 ring-primary/20">
+      <CardContent className="flex items-start gap-3">
+        <div className="shrink-0 mt-0.5 flex items-center justify-center w-8 h-8 rounded-full bg-primary/10">
+          <MapPin className="w-4 h-4 text-primary" />
+        </div>
+        <div className="flex-1 min-w-0 space-y-1">
+          <div className="flex items-center gap-2">
+            <p className="font-semibold text-sm leading-snug">{poi.name}</p>
+            <Badge variant="secondary" className="text-[0.625rem]">
+              {poi.category}
+            </Badge>
+          </div>
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            {poi.description}
+          </p>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            {poi.address && (
+              <span className="flex items-center gap-1">
+                <Navigation className="w-3 h-3" />
+                {poi.address}
+              </span>
+            )}
+            {poi.hours && (
+              <span className="flex items-center gap-1">
+                <Clock className="w-3 h-3" />
+                {poi.hours}
+              </span>
+            )}
+            {poi.rating && (
+              <span className="flex items-center gap-1">
+                <Star className="w-3 h-3 fill-amber-400 text-amber-400" />
+                {poi.rating}/5
+              </span>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+const EVENT_TYPE_COLORS: Record<string, string> = {
+  "On-Campus": "bg-event-oncampus-bg text-event-oncampus-fg",
+  Online: "bg-event-online-bg text-event-online-fg",
+  External: "bg-event-external-bg text-event-external-fg",
+};
+
+function EventListCard({ output }: { output: ShowEventsOutput }) {
+  const { events, message } = output;
+
+  if (events.length === 0) {
+    return (
+      <Card size="sm" className="bg-muted/30">
+        <CardContent className="flex items-start gap-2.5">
+          <Calendar className="w-4 h-4 text-muted-foreground shrink-0 mt-0.5" />
+          <p className="text-sm text-muted-foreground">{message}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const displayEvents = events.slice(0, 5);
+  const remaining = events.length - displayEvents.length;
+
+  return (
+    <Card size="sm" className="bg-card">
+      <CardContent className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Calendar className="w-4 h-4 text-primary shrink-0" />
+          <p className="text-xs font-medium text-muted-foreground">{message}</p>
+        </div>
+        <div className="space-y-1.5">
+          {displayEvents.map((event) => {
+            const dateDisplay = event.endDate
+              ? `${event.date} \u2013 ${event.endDate}`
+              : event.date;
+            return (
+              <div
+                key={event.id}
+                className="flex flex-col gap-1 rounded-lg border p-2.5 text-sm"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <span className="font-medium text-[0.8125rem] leading-snug">
+                    {event.title}
+                  </span>
+                  <Badge variant="secondary" className="text-[0.625rem] shrink-0">
+                    {event.category}
+                  </Badge>
+                </div>
+                <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
+                  <span>{dateDisplay}</span>
+                  <span>&middot;</span>
+                  <span>{event.time}</span>
+                  <span>&middot;</span>
+                  <span className="truncate max-w-[140px]">{event.location}</span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  {event.type && (
+                    <span
+                      className={cn(
+                        "text-[0.625rem] px-1.5 py-0.5 rounded-full font-medium",
+                        EVENT_TYPE_COLORS[event.type] ?? "bg-muted text-muted-foreground"
+                      )}
+                    >
+                      {event.type}
+                    </span>
+                  )}
+                  {event.school && (
+                    <span className="text-[0.625rem] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground font-medium">
+                      {event.school}
+                    </span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        {remaining > 0 && (
+          <p className="text-xs text-muted-foreground text-center pt-1">
+            +{remaining} more event{remaining > 1 ? "s" : ""} — check the Events
+            tab for all results
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function CampusInfoCard({ output }: { output: CampusInfoOutput }) {
+  return (
+    <Card size="sm" className="bg-card">
+      <CardContent className="space-y-2">
+        <div className="flex items-start gap-2.5">
+          <Info className="w-4 h-4 text-primary shrink-0 mt-0.5" />
+          <p className="text-sm leading-relaxed whitespace-pre-line">
+            {output.answer}
+          </p>
+        </div>
+        {output.venues && output.venues.length > 0 && (
+          <div className="space-y-1.5 pl-6">
+            {output.venues.map((venue) => (
+              <div
+                key={venue.id}
+                className="flex items-start gap-2 rounded-lg border p-2 text-xs"
+              >
+                <MapPin className="w-3 h-3 text-primary shrink-0 mt-0.5" />
+                <div className="flex-1 min-w-0">
+                  <span className="font-medium">{venue.name}</span>
+                  {venue.address && (
+                    <span className="text-muted-foreground">
+                      {" "}
+                      &mdash; {venue.address}
+                    </span>
+                  )}
+                  <div className="flex items-center gap-2 text-muted-foreground mt-0.5">
+                    {venue.hours && (
+                      <span className="flex items-center gap-0.5">
+                        <Clock className="w-2.5 h-2.5" />
+                        {venue.hours}
+                      </span>
+                    )}
+                    {venue.rating && (
+                      <span className="flex items-center gap-0.5">
+                        <Star className="w-2.5 h-2.5 fill-amber-400 text-amber-400" />
+                        {venue.rating}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface ToolResultCardProps {
+  toolName: string;
+  output: Record<string, unknown>;
+  state: string;
+}
+
+function ToolResultCardInner({ toolName, output, state }: ToolResultCardProps) {
+  if (state !== "output-available") {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground py-1">
+        <span className="inline-flex gap-1">
+          <span className="animate-bounce text-primary">&middot;</span>
+          <span
+            className="animate-bounce text-primary"
+            style={{ animationDelay: "0.1s" }}
+          >
+            &middot;
+          </span>
+          <span
+            className="animate-bounce text-primary"
+            style={{ animationDelay: "0.2s" }}
+          >
+            &middot;
+          </span>
+        </span>
+        <span className="text-xs italic">
+          {toolName === "navigate_to"
+            ? "Finding location..."
+            : toolName === "show_events"
+              ? "Searching events..."
+              : "Looking up campus info..."}
+        </span>
+      </div>
+    );
+  }
+
+  switch (toolName) {
+    case "navigate_to":
+      return <LocationCard output={output as unknown as NavigateOutput} />;
+    case "show_events":
+      return <EventListCard output={output as unknown as ShowEventsOutput} />;
+    case "campus_info":
+      return <CampusInfoCard output={output as unknown as CampusInfoOutput} />;
+    default:
+      return null;
+  }
+}
+
+const ToolResultCard = memo(ToolResultCardInner);
+ToolResultCard.displayName = "ToolResultCard";
+
+export default ToolResultCard;


### PR DESCRIPTION
## Summary

Implements Spec 003: Fix Chat Streaming & Tool Result Rendering.

- **Rich tool result cards** — `navigate_to` renders location cards with POI name, category badge, address, hours, rating; `show_events` renders event list cards (up to 5) with type/school badges; `campus_info` renders info cards with venue listings
- **Multi-turn tool call support** — `renderAssistantParts` iterates message parts in order, interleaving text bubbles and tool result cards so consecutive tool calls (navigate → show_events) each render as separate cards
- **Thinking indicator** — Shows animated dots with "Thinking..." label during tool execution (`input-streaming`/`input-available` states), not just on initial submit
- **Inline error display with retry** — Replaces toast-only errors with inline error card showing AlertCircle icon, error message, and a Retry button that resends the last failed message
- **New component** — `ToolResultCard.tsx` uses shadcn/ui Card + Badge, Lucide icons, existing design tokens (OKLCH colors, event type colors)

## Verification

- `npm run build` passes with 0 errors
- `npm run lint` passes with 0 errors (3 pre-existing warnings unchanged)
- Follows constitution: no `as any`, no `@ts-ignore`, single-responsibility components, Tailwind + OKLCH tokens, Lucide icons

## Affected Files

- `src/components/chat/ToolResultCard.tsx` — **NEW** (273 lines)
- `src/components/chat/ChatPanel.tsx` — **MODIFIED** (refactored message rendering)