### PR TITLE
feat: add all AIC offices as POIs with services knowledge

### DIFF
--- a/src/lib/ai/system-prompt.ts
+++ b/src/lib/ai/system-prompt.ts
@@ -138,4 +138,46 @@ When a student or user asks about AACs, you can:
 - Explain eligibility (Singapore Citizens/PRs aged 60+, free of charge)
 
 All AACs are typically open Mon–Fri 9AM–5PM (some vary). Seniors can walk in to their nearest AAC to register.
+
+## Agency for Integrated Care (AIC)
+
+AIC is Singapore's national agency for community care, supporting seniors and caregivers with services, schemes, and outreach. SUSS social work and gerontology students may interact with AIC services during fieldwork.
+
+### AIC Hotline
+- **Phone**: 1800-650-6060 (English, Chinese, Malay, Tamil)
+- **Hours**: Mon–Fri 8:30AM–8:30PM, Sat 8:30AM–4PM, Closed Sun & PH
+- **Email**: enquiries@aic.sg
+
+### AIC Headquarters
+- 5 Maxwell Road, #10-00 Tower Block, MND Complex, S069110
+- Mon–Fri 8:30AM–5:30PM
+
+### AIC Link Centres
+Walk-in advice centres at major hospitals for care services and financial assistance:
+- AIC Link @ Singapore General Hospital (SGH) — near Koufu Food Court
+- AIC Link @ Tan Tock Seng Hospital (TTSH)
+- AIC Link @ Changi General Hospital (CGH)
+- AIC Link @ Khoo Teck Puat Hospital (KTPH)
+- AIC Link @ National University Hospital (NUH) — closest to SUSS
+- AIC Link @ Sengkang General Hospital (SKH)
+- AIC Link @ Ng Teng Fong General Hospital (NTFGH)
+- AIC Link @ Alexandra Hospital
+- Hours: Mon–Fri 8:30AM–5:30PM
+
+### AIC Link Services
+- Care at Home: home care, home personal care, eldersitter service (dementia), home-based intervention
+- Centre-based Care: day care, dementia day care, day rehabilitation
+- Financial Assistance: ElderFund, CHAS, Home Caregiving Grant (HCG), Seniors' Mobility and Enabling Fund (SMF), Pioneer Generation Disability Assistance Scheme (PioneerDAS), Foreign Domestic Worker Levy Concession
+- Caregiver Support: Caregivers Training Grant (CTG), respite care
+- Nursing Home Placement assistance
+
+### Silver Generation Office (SGO)
+SGO is part of AIC. Volunteers conduct door-to-door outreach to seniors for functional screening, care service referrals, health education, befriending, and community programme enrolment. 17 satellite offices across Singapore:
+- **Central**: Ang Mo Kio, Bishan-Toa Payoh, Jalan Besar
+- **South**: Tanjong Pagar, Marine Parade
+- **East**: East Coast, Aljunied, Tampines, Pasir Ris-Punggol, Sengkang
+- **West**: Holland-Bukit Timah, West Coast, Jurong, Choa Chu Kang
+- **North**: Marsiling-Yew Tee, Nee Soon, Sembawang
+
+When students ask about AIC, eldercare, caregiver support, nursing homes, or senior services, provide relevant AIC information and use navigate_to to show the nearest AIC office on the map.
 `;

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -119,6 +119,15 @@ export const campusInfo = tool({
       "food centre": "Hawker",
       building: "Building",
       block: "Building",
+      aic: "AIC Office",
+      "aic office": "AIC Office",
+      "aic link": "AIC Office",
+      sgo: "AIC Office",
+      "silver generation": "AIC Office",
+      caregiver: "AIC Office",
+      eldercare: "AIC Office",
+      "elderfund": "AIC Office",
+      "nursing home": "AIC Office",
     };
 
     const matchedCategory = Object.entries(categoryKeywords).find(([kw]) => q.includes(kw));
@@ -178,6 +187,17 @@ export const campusInfo = tool({
       starbucks: "Starbucks is in Block C, Level 1.",
       "study room":
         "Study spaces are available at Block B Level 3, Block C Level 4, and the SUSS Library (Block C Level 2) with 5 discussion rooms.",
+      aic: "AIC (Agency for Integrated Care) provides community care services for seniors and caregivers in Singapore. AIC Hotline: 1800-650-6060 (Mon–Fri 8:30AM–8:30PM, Sat 8:30AM–4PM). AIC Link centres are located at major hospitals (SGH, TTSH, CGH, KTPH, NUH, SKH, NTFGH, Alexandra Hospital). Silver Generation Office (SGO) has 17 satellite offices across Singapore for senior outreach. HQ: 5 Maxwell Road, #10-00 Tower Block, MND Complex, S069110. Email: enquiries@aic.sg",
+      "aic link":
+        "AIC Link centres provide walk-in advice on care services and schemes including: ElderFund, CHAS, Home Caregiving Grant (HCG), Seniors' Mobility and Enabling Fund (SMF), Caregivers Training Grant (CTG), nursing home and day care placement, dementia support, and respite care. Located at major hospitals: SGH, TTSH, CGH, KTPH, NUH, SKH, NTFGH, and Alexandra Hospital. Hours: Mon–Fri 8:30AM–5:30PM.",
+      "silver generation":
+        "The Silver Generation Office (SGO) is part of AIC. SGO volunteers conduct door-to-door outreach to seniors, connecting them to care services, health screenings (functional screening), and community programmes. 17 satellite offices across Singapore covering Ang Mo Kio, Bishan-Toa Payoh, Jalan Besar, Tanjong Pagar, Marine Parade, East Coast, Aljunied, Tampines, Pasir Ris-Punggol, Sengkang, Holland-Bukit Timah, West Coast, Jurong, Choa Chu Kang, Marsiling-Yew Tee, Nee Soon, and Sembawang.",
+      caregiver:
+        "AIC supports caregivers with: Caregivers Training Grant (CTG) for subsidised training, respite care to give caregivers a break, Home Caregiving Grant (HCG) for monthly cash payouts, and caregiver support resources. Call AIC Hotline 1800-650-6060 or visit any AIC Link centre at major hospitals.",
+      eldercare:
+        "AIC eldercare services include: home care, day care, dementia day care, day rehabilitation, nursing home placement, ElderFund, Seniors' Mobility and Enabling Fund (SMF), Home Caregiving Grant (HCG), and Pioneer Generation Disability Assistance Scheme. Call AIC Hotline 1800-650-6060.",
+      "nursing home":
+        "For nursing home placement assistance, visit any AIC Link centre at major hospitals or call AIC Hotline 1800-650-6060. AIC Care Consultants can help assess care needs and find suitable facilities. Financial assistance (ElderFund, Medifund) may be available.",
     };
 
     const matched = Object.entries(info).find(([key]) => q.includes(key));

--- a/src/lib/maps/aic-offices.ts
+++ b/src/lib/maps/aic-offices.ts
@@ -1,0 +1,338 @@
+import type { POI } from "@/types";
+
+/**
+ * Agency for Integrated Care (AIC) offices across Singapore.
+ *
+ * Includes:
+ * - AIC Headquarters
+ * - AIC Link centres (at major hospitals)
+ * - Silver Generation Office (SGO) satellite offices (community outreach)
+ *
+ * AIC Hotline: 1800-650-6060
+ * Mon–Fri 8:30AM–8:30PM, Sat 8:30AM–4PM, Closed Sun & PH
+ */
+
+export const AIC_HOTLINE = "1800-650-6060";
+
+export const AIC_OFFICES: POI[] = [
+  // ── AIC Headquarters ────────────────────────────────────────
+  {
+    id: "aic-hq",
+    name: "AIC Headquarters",
+    lat: 1.2797,
+    lng: 103.8459,
+    category: "AIC Office",
+    description:
+      "Agency for Integrated Care HQ. Services: Caregiver Support, ElderFund, ElderShield, nursing home placement, MediSave for Integrated Shield Plans, Home Caregiving Grant (HCG), Seniors' Mobility and Enabling Fund (SMF), AIC Hotline 1800-650-6060.",
+    address: "5 Maxwell Road, #10-00 Tower Block, MND Complex, S069110",
+    hours: "Mon–Fri 8:30AM–5:30PM",
+    contact: AIC_HOTLINE,
+  },
+
+  // ── AIC Link Centres (Major Hospitals) ──────────────────────
+  {
+    id: "aic-link-sgh",
+    name: "AIC Link @ Singapore General Hospital",
+    lat: 1.2793,
+    lng: 103.8358,
+    category: "AIC Office",
+    description:
+      "AIC Link at SGH, near Koufu Food Court. Walk-in advice on care services, financial assistance (ElderFund, CHAS, HCG, SMF), caregiver training grants, nursing home/day care placement, and dementia support.",
+    address: "Outram Road, Singapore General Hospital, S169608",
+    hours: "Mon–Fri 8:30AM–5:30PM",
+    contact: AIC_HOTLINE,
+  },
+  {
+    id: "aic-link-ttsh",
+    name: "AIC Link @ Tan Tock Seng Hospital",
+    lat: 1.3215,
+    lng: 103.8467,
+    category: "AIC Office",
+    description:
+      "AIC Link at TTSH. Walk-in advice on care services, financial assistance (ElderFund, CHAS, HCG, SMF), caregiver training grants, nursing home/day care placement, and dementia support.",
+    address: "11 Jalan Tan Tock Seng, S308433",
+    hours: "Mon–Fri 8:30AM–5:30PM",
+    contact: AIC_HOTLINE,
+  },
+  {
+    id: "aic-link-cgh",
+    name: "AIC Link @ Changi General Hospital",
+    lat: 1.3401,
+    lng: 103.9494,
+    category: "AIC Office",
+    description:
+      "AIC Link at CGH. Walk-in advice on care services, financial assistance (ElderFund, CHAS, HCG, SMF), caregiver training grants, nursing home/day care placement, and dementia support.",
+    address: "2 Simei Street 3, S529889",
+    hours: "Mon–Fri 8:30AM–5:30PM",
+    contact: AIC_HOTLINE,
+  },
+  {
+    id: "aic-link-ktph",
+    name: "AIC Link @ Khoo Teck Puat Hospital",
+    lat: 1.4244,
+    lng: 103.8381,
+    category: "AIC Office",
+    description:
+      "AIC Link at KTPH. Walk-in advice on care services, financial assistance (ElderFund, CHAS, HCG, SMF), caregiver training grants, nursing home/day care placement, and dementia support.",
+    address: "90 Yishun Central, S768828",
+    hours: "Mon–Fri 8:30AM–5:30PM",
+    contact: AIC_HOTLINE,
+  },
+  {
+    id: "aic-link-nuh",
+    name: "AIC Link @ National University Hospital",
+    lat: 1.2936,
+    lng: 103.7831,
+    category: "AIC Office",
+    description:
+      "AIC Link at NUH. Walk-in advice on care services, financial assistance (ElderFund, CHAS, HCG, SMF), caregiver training grants, nursing home/day care placement, and dementia support.",
+    address: "5 Lower Kent Ridge Road, S119074",
+    hours: "Mon–Fri 8:30AM–5:30PM",
+    contact: AIC_HOTLINE,
+  },
+  {
+    id: "aic-link-skh",
+    name: "AIC Link @ Sengkang General Hospital",
+    lat: 1.3944,
+    lng: 103.8935,
+    category: "AIC Office",
+    description:
+      "AIC Link at SKH. Walk-in advice on care services, financial assistance (ElderFund, CHAS, HCG, SMF), caregiver training grants, nursing home/day care placement, and dementia support.",
+    address: "110 Sengkang East Way, S544886",
+    hours: "Mon–Fri 8:30AM–5:30PM",
+    contact: AIC_HOTLINE,
+  },
+  {
+    id: "aic-link-ntfgh",
+    name: "AIC Link @ Ng Teng Fong General Hospital",
+    lat: 1.3331,
+    lng: 103.7457,
+    category: "AIC Office",
+    description:
+      "AIC Link at NTFGH. Walk-in advice on care services, financial assistance (ElderFund, CHAS, HCG, SMF), caregiver training grants, nursing home/day care placement, and dementia support.",
+    address: "1 Jurong East Street 21, S609606",
+    hours: "Mon–Fri 8:30AM–5:30PM",
+    contact: AIC_HOTLINE,
+  },
+  {
+    id: "aic-link-ach",
+    name: "AIC Link @ Alexandra Hospital",
+    lat: 1.2864,
+    lng: 103.7991,
+    category: "AIC Office",
+    description:
+      "AIC Link at Alexandra Hospital. Walk-in advice on care services, financial assistance (ElderFund, CHAS, HCG, SMF), caregiver training grants, nursing home/day care placement, and dementia support.",
+    address: "378 Alexandra Road, S159964",
+    hours: "Mon–Fri 8:30AM–5:30PM",
+    contact: AIC_HOTLINE,
+  },
+
+  // ── Silver Generation Office (SGO) Satellite Offices ────────
+  // SGO volunteers conduct door-to-door outreach to seniors,
+  // connecting them to care services, health screenings, and
+  // community programmes.
+  {
+    id: "sgo-ang-mo-kio",
+    name: "SGO – Ang Mo Kio",
+    lat: 1.3750,
+    lng: 103.8490,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for Ang Mo Kio (Central Cluster). Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "723 Ang Mo Kio Ave 8, S560723",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: "6553 6016",
+  },
+  {
+    id: "sgo-bishan-toa-payoh",
+    name: "SGO – Bishan-Toa Payoh",
+    lat: 1.3340,
+    lng: 103.8500,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for Bishan-Toa Payoh (Central Cluster). Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Blk 125A Lorong 2 Toa Payoh, #02-136, S311125",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: "6956 7014",
+  },
+  {
+    id: "sgo-jalan-besar",
+    name: "SGO – Jalan Besar",
+    lat: 1.3128,
+    lng: 103.8580,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for Jalan Besar (Central Cluster). Located at Kwong Wai Shiu Hospital. Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Kwong Wai Shiu Hospital, 705 Serangoon Road, Block A #02-03, S328127",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: "6296 1013",
+  },
+  {
+    id: "sgo-tanjong-pagar",
+    name: "SGO – Tanjong Pagar",
+    lat: 1.2754,
+    lng: 103.8415,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for Tanjong Pagar (South Cluster). Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Blk 1 Everton Park, #01-27, S081001",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: AIC_HOTLINE,
+  },
+  {
+    id: "sgo-marine-parade",
+    name: "SGO – Marine Parade",
+    lat: 1.3020,
+    lng: 103.9059,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for Marine Parade (South Cluster). Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Blk 50 Marine Terrace, #01-260, S440050",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: AIC_HOTLINE,
+  },
+  {
+    id: "sgo-east-coast",
+    name: "SGO – East Coast",
+    lat: 1.3260,
+    lng: 103.9310,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for East Coast (East Cluster). Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Blk 124 Bedok North Road, #01-133, S460124",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: "6636 2535",
+  },
+  {
+    id: "sgo-aljunied",
+    name: "SGO – Aljunied",
+    lat: 1.3581,
+    lng: 103.8862,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for Aljunied (East Cluster). Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Punggol Community Club, 3 Hougang Ave 6, #01-02, S538808",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: "6383 6022",
+  },
+  {
+    id: "sgo-tampines",
+    name: "SGO – Tampines",
+    lat: 1.3535,
+    lng: 103.9395,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for Tampines (East Cluster). Located at Our Tampines Hub. Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Our Tampines Hub, 1 Tampines Walk, #04-35, S528523",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: "6587 6925",
+  },
+  {
+    id: "sgo-pasir-ris-punggol",
+    name: "SGO – Pasir Ris-Punggol",
+    lat: 1.3917,
+    lng: 103.8951,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for Pasir Ris-Punggol (East Cluster). Located at Sengkang Community Club. Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Sengkang Community Club, 2 Sengkang Square, #05-01, S545025",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: "6636 2760",
+  },
+  {
+    id: "sgo-sengkang",
+    name: "SGO – Sengkang",
+    lat: 1.3916,
+    lng: 103.8943,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for Sengkang (East Cluster). Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Blk 257C Compassvale Road, #01-05, S543257",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: AIC_HOTLINE,
+  },
+  {
+    id: "sgo-holland-bukit-timah",
+    name: "SGO – Holland-Bukit Timah",
+    lat: 1.3112,
+    lng: 103.7887,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for Holland-Bukit Timah (North Cluster). Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Blk 3 Ghim Moh Road, #01-271, S270003",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: AIC_HOTLINE,
+  },
+  {
+    id: "sgo-west-coast",
+    name: "SGO – West Coast",
+    lat: 1.3048,
+    lng: 103.7550,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for West Coast (West Cluster). Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Blk 502 West Coast Drive, #01-169, S120502",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: AIC_HOTLINE,
+  },
+  {
+    id: "sgo-jurong",
+    name: "SGO – Jurong",
+    lat: 1.3387,
+    lng: 103.7290,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for Jurong (West Cluster). Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Blk 334 Jurong East Ave 1, #01-07, S600334",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: AIC_HOTLINE,
+  },
+  {
+    id: "sgo-choa-chu-kang",
+    name: "SGO – Choa Chu Kang",
+    lat: 1.3851,
+    lng: 103.7468,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for Choa Chu Kang (West Cluster). Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Blk 304 Choa Chu Kang Ave 4, #01-665, S680304",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: AIC_HOTLINE,
+  },
+  {
+    id: "sgo-marsiling-yew-tee",
+    name: "SGO – Marsiling-Yew Tee",
+    lat: 1.3970,
+    lng: 103.7470,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for Marsiling-Yew Tee (North Cluster). Located at Yew Tee Community Building. Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Yew Tee Community Building, 20 Choa Chu Kang Street 52, #03-06/#03-07, S689286",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: "6363 7401",
+  },
+  {
+    id: "sgo-nee-soon",
+    name: "SGO – Nee Soon",
+    lat: 1.4290,
+    lng: 103.8370,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for Nee Soon (North Cluster). Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Blk 234 Yishun Street 21, #01-418, S760234",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: "6956 7100",
+  },
+  {
+    id: "sgo-sembawang",
+    name: "SGO – Sembawang",
+    lat: 1.4378,
+    lng: 103.7877,
+    category: "AIC Office",
+    description:
+      "Silver Generation Office for Sembawang (North Cluster). Located at Woodlands Galaxy Community Club. Volunteer-led senior outreach: functional screening, care service referrals, health education, befriending, and community programme enrolment.",
+    address: "Woodlands Galaxy Community Club, 31 Woodlands Ave 6, #04-01/#04-05, S738991",
+    hours: "Mon–Fri 9AM–6PM",
+    contact: "6767 1406",
+  },
+];

--- a/src/lib/maps/campus-pois.ts
+++ b/src/lib/maps/campus-pois.ts
@@ -1,9 +1,12 @@
 import type { POI } from "@/types";
 import { ACTIVE_AGEING_CENTRES } from "./active-ageing-centres";
+import { AIC_OFFICES } from "./aic-offices";
 
 export const CAMPUS_CENTER = { lat: 1.3299, lng: 103.7764 };
 
 export const CAMPUS_POIS: POI[] = [
+  ...AIC_OFFICES,
+
   // ── Campus Buildings ────────────────────────────────────────
   {
     id: "block-a",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,12 +9,12 @@ export interface POI {
   description: string;
   address?: string;
   hours?: string;
+  contact?: string;
   rating?: number;
   notes?: string;
   cuisine?: string;
   tags?: string[];
   distanceFromCampus?: string;
-  contact?: string;
   website?: string;
   priceLevel?: PriceLevel;
 }


### PR DESCRIPTION
## Summary

- Add **26 AIC (Agency for Integrated Care) locations** as POIs across Singapore: 1 HQ, 8 AIC Link hospital centres, 17 Silver Generation Office (SGO) satellite offices
- SGO addresses verified against **data.gov.sg** official dataset (June 2024)
- Integrate AIC knowledge into the `campus_info` AI tool and system prompt for eldercare/caregiver queries

## Changes

### New Files
- `src/lib/maps/aic-offices.ts` — 26 AIC office POIs with coordinates, addresses, hours, and contact numbers

### Modified Files
- `src/types/index.ts` — Add optional `contact` field to `POI` interface
- `src/lib/maps/campus-pois.ts` — Import and spread `AIC_OFFICES` into `CAMPUS_POIS`
- `src/lib/ai/tools.ts` — Add AIC/SGO/caregiver/eldercare category keywords and knowledge entries to `campus_info` tool
- `src/lib/ai/system-prompt.ts` — Add comprehensive AIC section (hotline, AIC Link services, SGO regions, financial assistance schemes)

## AIC Locations Added

| Type | Count | Details |
|------|-------|---------|
| **HQ** | 1 | 5 Maxwell Road, MND Complex |
| **AIC Link** | 8 | SGH, TTSH, CGH, KTPH, NUH, SKH, NTFGH, Alexandra Hospital |
| **SGO Offices** | 17 | Ang Mo Kio, Bishan-Toa Payoh, Jalan Besar, Tanjong Pagar, Marine Parade, East Coast, Aljunied, Tampines, Pasir Ris-Punggol, Sengkang, Holland-Bukit Timah, West Coast, Jurong, Choa Chu Kang, Marsiling-Yew Tee, Nee Soon, Sembawang |

## Testing
- `npx tsc --noEmit` — zero errors
- `npx eslint src` — zero errors (3 pre-existing warnings in unrelated files)
- `next build` — TypeScript compilation succeeds; pre-existing `_global-error` prerender issue unrelated to this PR