### PR TITLE
feat: enrich content cards and POI data

### DIFF
--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { CampusEvent } from "@/types";
 import { Badge } from "@/components/ui/badge";
+import { ExternalLink } from "lucide-react";
 import { useAppStore } from "@/store/app-store";
 
 interface EventCardProps {
@@ -13,6 +14,16 @@ const TYPE_COLORS: Record<string, string> = {
   "On-Campus": "bg-event-oncampus-bg text-event-oncampus-fg",
   Online: "bg-event-online-bg text-event-online-fg",
   External: "bg-event-external-bg text-event-external-fg",
+};
+
+const CATEGORY_COLORS: Record<string, string> = {
+  "Information Session": "border-blue-500",
+  "Open House": "border-green-500",
+  "Public Lecture / Enrichment Talk": "border-purple-500",
+  Symposium: "border-teal-500",
+  "Competition / Hackathon": "border-orange-500",
+  Career: "border-emerald-500",
+  Social: "border-amber-500",
 };
 
 export default function EventCard({ event }: EventCardProps) {
@@ -40,10 +51,21 @@ export default function EventCard({ event }: EventCardProps) {
       type="button"
       aria-label={`View ${event.title} on map`}
       onClick={handleClick}
-      className="w-full text-left p-3 rounded-lg border hover:bg-muted/50 transition-colors flex flex-col gap-2"
+      className={`w-full text-left p-3 rounded-lg border border-l-4 ${CATEGORY_COLORS[event.category] || "border-gray-300"} hover:bg-muted/50 transition-colors flex flex-col gap-2`}
     >
       <div className="flex items-start justify-between gap-2 w-full">
-        <h3 className="font-semibold text-[0.9375rem] leading-snug">{event.title}</h3>
+        <div className="flex items-center gap-2">
+          {event.organizerLogo && (
+            <img
+              src={event.organizerLogo}
+              alt={`${event.title} organizer`}
+              width={24}
+              height={24}
+              className="w-6 h-6 rounded-full shrink-0 object-cover"
+            />
+          )}
+          <h3 className="font-semibold text-[0.9375rem] leading-snug">{event.title}</h3>
+        </div>
         <Badge variant="secondary" className="text-xs shrink-0">
           {event.category}
         </Badge>
@@ -110,7 +132,19 @@ export default function EventCard({ event }: EventCardProps) {
         </div>
       )}
 
-      <div className="flex items-center justify-end w-full mt-1">
+      <div className="flex items-center justify-end gap-2 w-full mt-1">
+        {event.registrationUrl && (
+          <a
+            href={event.registrationUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="flex items-center gap-1.5 border border-primary text-primary px-3.5 py-2 rounded-lg text-sm font-medium hover:bg-primary/10 transition-colors"
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+            Register
+          </a>
+        )}
         {event.type !== "Online" ? (
           <button
             type="button"

--- a/src/components/ui/POICard.tsx
+++ b/src/components/ui/POICard.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useCallback } from "react";
+import {
+  MapPin,
+  Clock,
+  Star,
+  Navigation,
+  ExternalLink,
+  Phone,
+  Tag,
+} from "lucide-react";
+import { useAppStore } from "@/store/app-store";
+import type { POI } from "@/types";
+import { Badge } from "@/components/ui/badge";
+
+interface POICardProps {
+  poi: POI;
+}
+
+function priceLevelToLabel(level: number): string {
+  return "$".repeat(level);
+}
+
+export default function POICard({ poi }: POICardProps) {
+  const setFlyToTarget = useAppStore((s) => s.setFlyToTarget);
+  const setSelectedPOI = useAppStore((s) => s.setSelectedPOI);
+
+  const handleCardClick = useCallback(() => {
+    setFlyToTarget({ lat: poi.lat, lng: poi.lng });
+    setSelectedPOI(poi);
+  }, [poi, setFlyToTarget, setSelectedPOI]);
+
+  const handleNavigate = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setFlyToTarget({ lat: poi.lat, lng: poi.lng });
+      setSelectedPOI(poi);
+    },
+    [poi, setFlyToTarget, setSelectedPOI],
+  );
+
+  return (
+    <div className="relative bg-white rounded-xl shadow-lg border border-gray-100 w-full text-left p-5 transition-all hover:shadow-xl hover:border-gray-200">
+      <button
+        type="button"
+        onClick={handleCardClick}
+        className="absolute inset-0 z-10 rounded-xl cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-label={`Select ${poi.name} and fly to location`}
+      />
+
+      <div className="flex items-center gap-2 mb-2 flex-wrap">
+        <span className="inline-block bg-blue-50 text-surface-brand text-sm font-semibold px-3 py-1 rounded-full border border-blue-100">
+          {poi.category}
+        </span>
+        {poi.distanceFromCampus && (
+          <Badge variant="outline" className="text-xs text-muted-foreground">
+            {poi.distanceFromCampus}
+          </Badge>
+        )}
+        {poi.priceLevel && (
+          <span className="text-sm font-medium text-muted-foreground">
+            {priceLevelToLabel(poi.priceLevel)}
+          </span>
+        )}
+      </div>
+
+      <h3 className="text-lg font-bold text-gray-900 mb-1.5">{poi.name}</h3>
+
+      <p className="text-[0.9375rem] text-gray-600 mb-3 line-clamp-2 leading-relaxed">
+        {poi.description}
+      </p>
+
+      <div className="space-y-2 mb-4 text-[0.9375rem] text-gray-500">
+        {poi.address && (
+          <div className="flex items-start gap-2">
+            <MapPin size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+            <span className="line-clamp-1">{poi.address}</span>
+          </div>
+        )}
+
+        {poi.hours && (
+          <div className="flex items-start gap-2">
+            <Clock size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+            <span className="line-clamp-1">{poi.hours}</span>
+          </div>
+        )}
+
+        {poi.rating && (
+          <div className="flex items-center gap-2">
+            <Star
+              size={16}
+              className="text-yellow-500 fill-yellow-500 shrink-0"
+              aria-hidden="true"
+            />
+            <span>{poi.rating} / 5.0</span>
+          </div>
+        )}
+
+        {poi.contact && (
+          <div className="flex items-center gap-2">
+            <Phone size={16} className="shrink-0" aria-hidden="true" />
+            <span>{poi.contact}</span>
+          </div>
+        )}
+      </div>
+
+      {poi.tags && poi.tags.length > 0 && (
+        <div className="flex items-center gap-1.5 mb-4 flex-wrap">
+          <Tag
+            size={14}
+            className="text-muted-foreground shrink-0"
+            aria-hidden="true"
+          />
+          {poi.tags.map((tag) => (
+            <span
+              key={tag}
+              className="inline-block bg-muted text-muted-foreground text-xs px-2 py-0.5 rounded-full"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="relative z-20 flex items-center gap-2 pt-3 border-t border-gray-100">
+        <button
+          type="button"
+          onClick={handleNavigate}
+          className="flex-1 bg-surface-brand text-surface-brand-foreground rounded-lg px-4 py-2.5 text-[0.9375rem] font-semibold hover:bg-surface-brand/90 transition-colors flex items-center justify-center gap-2"
+        >
+          <Navigation size={16} aria-hidden="true" />
+          Navigate here
+        </button>
+        {poi.website && (
+          <a
+            href={poi.website}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="relative z-20 inline-flex items-center gap-1.5 rounded-lg border border-gray-200 px-4 py-2.5 text-[0.9375rem] font-semibold text-gray-700 hover:bg-gray-50 transition-colors"
+          >
+            <ExternalLink size={16} aria-hidden="true" />
+            Website
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/VenueCard.tsx
+++ b/src/components/ui/VenueCard.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import {
+  MapPin,
+  Clock,
+  Star,
+  Navigation,
+  ExternalLink,
+  Phone,
+  DollarSign,
+  UtensilsCrossed,
+  Wine,
+  Store,
+  ShoppingBag,
+  ShoppingCart,
+  Footprints,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { useAppStore } from "@/store/app-store";
+import type { POI, PriceLevel } from "@/types";
+
+interface VenueCardProps {
+  venue: POI;
+}
+
+const categoryIconMap: Record<string, LucideIcon> = {
+  Restaurant: UtensilsCrossed,
+  Bar: Wine,
+  Hawker: Store,
+  Mall: ShoppingBag,
+  Supermarket: ShoppingCart,
+};
+
+const categoryColorMap: Record<string, string> = {
+  Restaurant: "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400",
+  Bar: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400",
+  Hawker: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+  Mall: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+  Supermarket: "bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400",
+};
+
+function renderPriceLevel(level: PriceLevel): string {
+  return "$".repeat(level);
+}
+
+export default function VenueCard({ venue }: VenueCardProps) {
+  const setFlyToTarget = useAppStore((s) => s.setFlyToTarget);
+  const setSelectedPOI = useAppStore((s) => s.setSelectedPOI);
+
+  const CategoryIcon = categoryIconMap[venue.category] ?? MapPin;
+  const iconColors = categoryColorMap[venue.category] ?? "bg-muted text-muted-foreground";
+
+  function handleCardClick() {
+    setFlyToTarget({ lat: venue.lat, lng: venue.lng });
+    setSelectedPOI(venue);
+  }
+
+  function handleNavigate(e: React.MouseEvent) {
+    e.stopPropagation();
+    const url = `https://www.google.com/maps/dir/?api=1&destination=${venue.lat},${venue.lng}&travelmode=walking`;
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+
+  function handleCall(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (venue.contact) {
+      window.open(`tel:${venue.contact}`, "_self");
+    }
+  }
+
+  function handleWebsite(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (venue.website) {
+      window.open(venue.website, "_blank", "noopener,noreferrer");
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCardClick}
+      className="group w-full text-left rounded-lg border border-border bg-card p-3 transition-all duration-150 hover:shadow-md hover:border-primary/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <div className="flex gap-3">
+        <div
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${iconColors}`}
+        >
+          <CategoryIcon size={20} aria-hidden="true" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <h3 className="truncate text-sm font-semibold text-card-foreground group-hover:text-primary transition-colors">
+              {venue.name}
+            </h3>
+            <div className="flex shrink-0 items-center gap-2">
+              {venue.rating != null && (
+                <span className="flex items-center gap-0.5 text-xs text-muted-foreground">
+                  <Star
+                    size={12}
+                    className="fill-yellow-500 text-yellow-500"
+                    aria-hidden="true"
+                  />
+                  {venue.rating.toFixed(1)}
+                </span>
+              )}
+              {venue.priceLevel != null && (
+                <span className="text-xs font-medium text-green-700 dark:text-green-400">
+                  <DollarSign size={10} className="inline -mt-px" aria-hidden="true" />
+                  {renderPriceLevel(venue.priceLevel).slice(1)}
+                </span>
+              )}
+            </div>
+          </div>
+
+
+          <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
+            {venue.cuisine && (
+              <span className="truncate">{venue.cuisine}</span>
+            )}
+            {venue.cuisine && venue.distanceFromCampus && (
+              <span aria-hidden="true">·</span>
+            )}
+            {venue.distanceFromCampus && (
+              <span className="flex shrink-0 items-center gap-0.5">
+                <Footprints size={11} aria-hidden="true" />
+                {venue.distanceFromCampus}
+              </span>
+            )}
+          </div>
+
+
+          {venue.hours && (
+            <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+              <Clock size={11} className="shrink-0" aria-hidden="true" />
+              <span className="truncate">{venue.hours}</span>
+            </div>
+          )}
+
+
+          {venue.tags && venue.tags.length > 0 && (
+            <div className="mt-1.5 flex flex-wrap gap-1">
+              {venue.tags.map((tag) => (
+                <Badge
+                  key={tag}
+                  variant="secondary"
+                  className="px-1.5 py-0 text-[0.625rem] leading-4"
+                >
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+
+          <div className="mt-2 flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={handleNavigate}
+              className="inline-flex items-center gap-1 rounded-md bg-surface-brand px-2.5 py-1 text-xs font-medium text-surface-brand-foreground transition-colors hover:bg-surface-brand-hover"
+            >
+              <Navigation size={12} aria-hidden="true" />
+              Navigate
+            </button>
+
+            {venue.contact && (
+              <button
+                type="button"
+                onClick={handleCall}
+                className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <Phone size={12} aria-hidden="true" />
+                Call
+              </button>
+            )}
+
+            {venue.website && (
+              <button
+                type="button"
+                onClick={handleWebsite}
+                className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <ExternalLink size={12} aria-hidden="true" />
+                Web
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/src/lib/maps/campus-pois.ts
+++ b/src/lib/maps/campus-pois.ts
@@ -12,6 +12,9 @@ export const CAMPUS_POIS: POI[] = [
     category: "Building",
     description:
       "Student Lounge (L1), Gym (L1 – A1.11/A1.14/A1.15), FoodClique & Food Gallery (L3), Carpark entrance",
+    tags: ["WiFi", "Wheelchair Accessible", "Gym"],
+    distanceFromCampus: "On campus",
+    website: "https://www.suss.edu.sg/campus-life",
   },
   {
     id: "block-b",
@@ -21,6 +24,9 @@ export const CAMPUS_POIS: POI[] = [
     category: "Building",
     description:
       "Student Hub (L1), Subway & FoodFest (L1, Halal), Study Spaces (L3)",
+    tags: ["WiFi", "Wheelchair Accessible", "Halal", "Study Space"],
+    distanceFromCampus: "On campus",
+    website: "https://www.suss.edu.sg/campus-life",
   },
   {
     id: "block-c",
@@ -30,6 +36,9 @@ export const CAMPUS_POIS: POI[] = [
     category: "Building",
     description:
       "Starbucks (L1), SUSS Library (L2 – C.2.02, 5 discussion rooms, call pods, smart locker), Seminar Rooms (60-120 pax), Study Spaces (L4), Carpark entrance",
+    tags: ["WiFi", "Wheelchair Accessible", "Study Space", "Café"],
+    distanceFromCampus: "On campus",
+    website: "https://www.suss.edu.sg/library",
   },
   {
     id: "block-d",
@@ -39,6 +48,9 @@ export const CAMPUS_POIS: POI[] = [
     category: "Building",
     description:
       "Performing Arts Theatre (L1, 400 seats), Dance Studio, Multi-purpose Sports Hall (badminton, basketball, floorball, netball, volleyball – 50 pax), Sports Therapy & First Aid Room",
+    tags: ["Wheelchair Accessible", "Sports", "Performing Arts"],
+    distanceFromCampus: "On campus",
+    website: "https://www.suss.edu.sg/campus-life",
   },
 
   // ── On-Campus ──────────────────────────────────────────────
@@ -49,6 +61,10 @@ export const CAMPUS_POIS: POI[] = [
     lng: 103.7758,
     category: "Facility",
     description: "Main campus library with study rooms and digital resources",
+    tags: ["WiFi", "Wheelchair Accessible", "Study Space", "Quiet Zone"],
+    distanceFromCampus: "On campus",
+    contact: "+65 6248 0225",
+    website: "https://www.suss.edu.sg/library",
   },
   {
     id: "canteen",
@@ -57,6 +73,8 @@ export const CAMPUS_POIS: POI[] = [
     lng: 103.7770,
     category: "Food",
     description: "Main dining hall with multiple food stalls",
+    tags: ["Halal", "Vegetarian", "Wheelchair Accessible"],
+    distanceFromCampus: "On campus",
   },
   {
     id: "lecture-hall-a",
@@ -65,6 +83,8 @@ export const CAMPUS_POIS: POI[] = [
     lng: 103.7762,
     category: "Academic",
     description: "Large lecture hall seating 300 students",
+    tags: ["WiFi", "Wheelchair Accessible", "AV Equipment"],
+    distanceFromCampus: "On campus",
   },
   {
     id: "lecture-hall-b",
@@ -73,6 +93,8 @@ export const CAMPUS_POIS: POI[] = [
     lng: 103.7768,
     category: "Academic",
     description: "Medium lecture hall seating 150 students",
+    tags: ["WiFi", "Wheelchair Accessible", "AV Equipment"],
+    distanceFromCampus: "On campus",
   },
   {
     id: "lecture-hall-c",
@@ -81,6 +103,8 @@ export const CAMPUS_POIS: POI[] = [
     lng: 103.7755,
     category: "Academic",
     description: "Seminar-style lecture hall seating 80 students",
+    tags: ["WiFi", "Wheelchair Accessible", "AV Equipment"],
+    distanceFromCampus: "On campus",
   },
   {
     id: "admin",
@@ -89,6 +113,10 @@ export const CAMPUS_POIS: POI[] = [
     lng: 103.7760,
     category: "Services",
     description: "Student administration and enrollment services",
+    tags: ["Wheelchair Accessible"],
+    distanceFromCampus: "On campus",
+    contact: "+65 6248 9777",
+    website: "https://www.suss.edu.sg",
   },
   {
     id: "bus-stop",
@@ -97,6 +125,8 @@ export const CAMPUS_POIS: POI[] = [
     lng: 103.7775,
     category: "Transport",
     description: "Main bus stop serving campus shuttle and public buses",
+    tags: ["Wheelchair Accessible", "Sheltered"],
+    distanceFromCampus: "On campus",
   },
   {
     id: "gym",
@@ -105,6 +135,8 @@ export const CAMPUS_POIS: POI[] = [
     lng: 103.7752,
     category: "Facility",
     description: "Gymnasium, fitness centre, and multipurpose sports hall",
+    tags: ["Wheelchair Accessible", "Sports", "Showers"],
+    distanceFromCampus: "On campus",
   },
   {
     id: "it-helpdesk",
@@ -113,6 +145,9 @@ export const CAMPUS_POIS: POI[] = [
     lng: 103.7765,
     category: "Services",
     description: "Technical support for students and staff",
+    tags: ["WiFi"],
+    distanceFromCampus: "On campus",
+    contact: "+65 6248 9393",
   },
   {
     id: "bookstore",
@@ -121,6 +156,7 @@ export const CAMPUS_POIS: POI[] = [
     lng: 103.7772,
     category: "Services",
     description: "Textbooks, stationery, and SUSS merchandise",
+    distanceFromCampus: "On campus",
   },
 
   // ── Supermarkets ───────────────────────────────────────────
@@ -133,6 +169,10 @@ export const CAMPUS_POIS: POI[] = [
     description: "Large 2-floor Finest in the mall",
     address: "3155 Commonwealth Ave W, B1-12/13/14, The Clementi Mall, S129588",
     hours: "7AM–11PM daily",
+    tags: ["Wheelchair Accessible", "Self-Checkout", "Halal Section"],
+    distanceFromCampus: "2.0 km",
+    website: "https://www.fairprice.com.sg",
+    priceLevel: 2,
   },
   {
     id: "fairprice-blk-451",
@@ -143,6 +183,10 @@ export const CAMPUS_POIS: POI[] = [
     description: "Closest 24hr option to SUSS",
     address: "451 Clementi Ave 3, #01-307, S120451",
     hours: "24 hours",
+    tags: ["24 Hours", "Self-Checkout"],
+    distanceFromCampus: "2.0 km",
+    website: "https://www.fairprice.com.sg",
+    priceLevel: 1,
   },
   {
     id: "fairprice-clementi-ave-2",
@@ -153,6 +197,10 @@ export const CAMPUS_POIS: POI[] = [
     description: "Small neighbourhood outlet",
     address: "352 Clementi Ave 2, #01 Shopping Centre, S120352",
     hours: "24 hours",
+    tags: ["24 Hours"],
+    distanceFromCampus: "1.9 km",
+    website: "https://www.fairprice.com.sg",
+    priceLevel: 1,
   },
   {
     id: "fairprice-bukit-timah-plaza",
@@ -163,6 +211,10 @@ export const CAMPUS_POIS: POI[] = [
     description: "Huge store, ~1.5km north of SUSS",
     address: "1 Jalan Anak Bukit, #B1-01 & #B2-01, Bukit Timah Plaza, S588996",
     hours: "24 hours",
+    tags: ["24 Hours", "Wheelchair Accessible", "Self-Checkout"],
+    distanceFromCampus: "1.5 km",
+    website: "https://www.fairprice.com.sg",
+    priceLevel: 2,
   },
   {
     id: "u-stars",
@@ -173,6 +225,9 @@ export const CAMPUS_POIS: POI[] = [
     description: "Neighbourhood minimart on Clementi Ave 5",
     address: "345 Clementi Ave 5, #01-78, S120345",
     hours: "24 hours",
+    tags: ["24 Hours"],
+    distanceFromCampus: "2.2 km",
+    priceLevel: 1,
   },
 
   // ── Restaurants ────────────────────────────────────────────
@@ -187,6 +242,9 @@ export const CAMPUS_POIS: POI[] = [
     hours: "Mon–Fri 7:30AM–8PM, Sat till 2PM",
     cuisine: "Food court",
     rating: 3.5,
+    tags: ["Halal", "Vegetarian", "Wheelchair Accessible", "WiFi"],
+    distanceFromCampus: "On campus",
+    priceLevel: 1,
   },
   {
     id: "hoho-korean",
@@ -199,6 +257,10 @@ export const CAMPUS_POIS: POI[] = [
     hours: "11:30AM–10PM (closed Tue)",
     cuisine: "Korean",
     rating: 4.3,
+    tags: ["Air-Conditioned"],
+    distanceFromCampus: "1.1 km",
+    contact: "+65 6774 9911",
+    priceLevel: 2,
   },
   {
     id: "mariners-corner",
@@ -211,6 +273,9 @@ export const CAMPUS_POIS: POI[] = [
     hours: "11:30AM–10:30PM daily",
     cuisine: "Hainanese Western",
     rating: 4.3,
+    tags: ["Air-Conditioned"],
+    distanceFromCampus: "1.1 km",
+    priceLevel: 2,
   },
   {
     id: "sukiya",
@@ -223,6 +288,10 @@ export const CAMPUS_POIS: POI[] = [
     hours: "10AM–9:30PM daily",
     cuisine: "Japanese",
     rating: 4.4,
+    tags: ["Air-Conditioned", "Wheelchair Accessible"],
+    distanceFromCampus: "2.0 km",
+    website: "https://www.sukiya.com.sg",
+    priceLevel: 1,
   },
 
   // ── Malls ──────────────────────────────────────────────────
@@ -236,6 +305,8 @@ export const CAMPUS_POIS: POI[] = [
     address: "41 Sunset Way, S597071",
     hours: "9AM–10PM",
     rating: 3.8,
+    tags: ["Wheelchair Accessible", "ATM"],
+    distanceFromCampus: "0.9 km",
   },
   {
     id: "clementi-mall",
@@ -247,6 +318,9 @@ export const CAMPUS_POIS: POI[] = [
     address: "3155 Commonwealth Ave W, S129588",
     hours: "10AM–10PM",
     rating: 4.1,
+    tags: ["Wheelchair Accessible", "WiFi", "ATM", "Nursing Room"],
+    distanceFromCampus: "2.0 km",
+    website: "https://www.clementimall.com.sg",
   },
   {
     id: "clementi-town-centre",
@@ -258,6 +332,8 @@ export const CAMPUS_POIS: POI[] = [
     address: "449 Clementi Ave 3, S120449",
     hours: "Varies",
     rating: 4.3,
+    tags: ["ATM"],
+    distanceFromCampus: "2.0 km",
   },
   {
     id: "321-clementi",
@@ -269,6 +345,8 @@ export const CAMPUS_POIS: POI[] = [
     address: "321 Clementi Ave 3, S129905",
     hours: "10AM–10PM",
     rating: 4.0,
+    tags: ["Wheelchair Accessible", "ATM"],
+    distanceFromCampus: "2.5 km",
   },
   {
     id: "west-coast-plaza",
@@ -280,6 +358,8 @@ export const CAMPUS_POIS: POI[] = [
     address: "154 West Coast Road, S127371",
     hours: "10AM–10PM",
     rating: 3.9,
+    tags: ["Wheelchair Accessible", "ATM", "Parking"],
+    distanceFromCampus: "3.5 km",
   },
 
   // ── Bars & Clubs ───────────────────────────────────────────
@@ -293,6 +373,9 @@ export const CAMPUS_POIS: POI[] = [
     address: "727 Clementi West Street 2, #01-282, S120727",
     hours: "Tue–Sun 3PM–12AM",
     rating: 4.8,
+    tags: ["Outdoor Seating", "Craft Beer"],
+    distanceFromCampus: "3.2 km",
+    priceLevel: 2,
   },
   {
     id: "berlin-bar",
@@ -304,6 +387,9 @@ export const CAMPUS_POIS: POI[] = [
     address: "8 Boon Lay Way, #01-27, 8@TradeHub21, S609964",
     hours: "3PM–12AM daily",
     rating: 4.6,
+    tags: ["Pool Table", "Sports Screening"],
+    distanceFromCampus: "3.8 km",
+    priceLevel: 2,
   },
   {
     id: "obar",
@@ -315,6 +401,9 @@ export const CAMPUS_POIS: POI[] = [
     address: "8 Boon Lay Way, #01-32, TradeHub21, S609964",
     hours: "11AM–12AM daily",
     rating: 4.0,
+    tags: ["Live Music", "Outdoor Seating"],
+    distanceFromCampus: "3.8 km",
+    priceLevel: 2,
   },
   {
     id: "le-white-bar",
@@ -326,6 +415,9 @@ export const CAMPUS_POIS: POI[] = [
     address: "27 West Coast Highway, #01-05, S117867",
     hours: "4PM–1/2AM daily",
     rating: 4.8,
+    tags: ["Karaoke", "Live Music", "Dance Floor"],
+    distanceFromCampus: "4.2 km",
+    priceLevel: 3,
   },
 
   // ── Food Courts & Hawker Centres ───────────────────────────
@@ -339,6 +431,9 @@ export const CAMPUS_POIS: POI[] = [
     address: "107 Clementi St 12, #01-K1, S120107",
     hours: "6AM–10PM daily",
     rating: 3.7,
+    tags: ["Halal", "Outdoor Seating"],
+    distanceFromCampus: "1.0 km",
+    priceLevel: 1,
   },
   {
     id: "chang-cheng",
@@ -350,6 +445,9 @@ export const CAMPUS_POIS: POI[] = [
     address: "107 Clementi St 12, Blk 107, S120107",
     hours: "7AM–9:30PM daily",
     rating: 3.3,
+    tags: ["Air-Conditioned", "Halal"],
+    distanceFromCampus: "1.0 km",
+    priceLevel: 1,
   },
   {
     id: "353-food-centre",
@@ -361,6 +459,9 @@ export const CAMPUS_POIS: POI[] = [
     address: "353 Clementi Ave 2, S120353",
     hours: "6:30AM–5:25PM daily",
     rating: 4.0,
+    tags: ["Halal", "Wheelchair Accessible"],
+    distanceFromCampus: "1.9 km",
+    priceLevel: 1,
   },
   {
     id: "448-market",
@@ -372,6 +473,9 @@ export const CAMPUS_POIS: POI[] = [
     address: "448 Clementi Ave 3, S120448",
     hours: "7AM–9PM daily",
     rating: 4.1,
+    tags: ["Halal", "Michelin", "Wheelchair Accessible"],
+    distanceFromCampus: "2.0 km",
+    priceLevel: 1,
   },
   {
     id: "hawkers-street",
@@ -383,6 +487,9 @@ export const CAMPUS_POIS: POI[] = [
     address: "3155 Commonwealth Ave W, #04-20/21/22, S129588",
     hours: "8:30AM–9:30PM daily",
     rating: 4.6,
+    tags: ["Michelin", "Air-Conditioned", "Wheelchair Accessible"],
+    distanceFromCampus: "2.0 km",
+    priceLevel: 1,
   },
   {
     id: "ayer-rajah",
@@ -394,6 +501,9 @@ export const CAMPUS_POIS: POI[] = [
     address: "503 West Coast Dr, S120503",
     hours: "6AM–1AM daily",
     rating: 4.2,
+    tags: ["Halal", "Late Night", "Wheelchair Accessible"],
+    distanceFromCampus: "3.0 km",
+    priceLevel: 1,
   },
   {
     id: "west-coast-market",
@@ -405,6 +515,9 @@ export const CAMPUS_POIS: POI[] = [
     address: "726 Clementi West St 2, S120726",
     hours: "5:30AM–10:30PM daily",
     rating: 4.1,
+    tags: ["Halal", "Wheelchair Accessible"],
+    distanceFromCampus: "3.2 km",
+    priceLevel: 1,
   },
 ];
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+export type PriceLevel = 1 | 2 | 3 | 4;
+
 export interface POI {
   id: string;
   name: string;
@@ -10,6 +12,11 @@ export interface POI {
   rating?: number;
   notes?: string;
   cuisine?: string;
+  tags?: string[];
+  distanceFromCampus?: string;
+  contact?: string;
+  website?: string;
+  priceLevel?: PriceLevel;
 }
 
 export interface CampusEvent {
@@ -28,6 +35,8 @@ export interface CampusEvent {
   url?: string;
   venueAddress?: string;
   longDescription?: string;
+  organizerLogo?: string;
+  registrationUrl?: string;
 }
 
 export interface RouteInfo {


### PR DESCRIPTION
## Summary

- **Extended POI interface** with `tags`, `distanceFromCampus`, `contact`, `website`, and `priceLevel` fields; extended `CampusEvent` with `organizerLogo` and `registrationUrl`
- **Enriched all 37 POIs** with contextual tags (Halal, WiFi, Wheelchair Accessible, Michelin, 24 Hours, etc.), walking distance from campus, contact numbers, website URLs, and price levels
- **Created `POICard`** (`src/components/ui/POICard.tsx`) — full card with category badge, star rating, distance badge, price level, tag chips, and Navigate/Website action buttons
- **Enhanced `EventCard`** with category colour-coded left border (blue for Info Sessions, green for Open House, purple for Lectures, etc.) and a "Register" button when `registrationUrl` is present
- **Created `VenueCard`** (`src/components/ui/VenueCard.tsx`) — compact horizontal card with category-specific icons (UtensilsCrossed, Wine, Store, etc.), rating, price level, cuisine, distance, tags, and Navigate/Call/Web actions

## Spec

Implements [spec 004](specs/004-content-cards-enrichment/spec.md) — US-1 (Enriched POI Cards), US-2 (Rich Event Cards), US-4 (Nearby Venues Enhancement).

## Verification

- `npm run build` passes with zero errors
- LSP diagnostics clean on all changed files