### PR TITLE
feat(ux): minimizable expandable info cards with swipe gestures

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -83,9 +83,8 @@ export default function AppShell() {
   const setActivePanel = useAppStore((s) => s.setActivePanel);
   const ttsEnabled = useAppStore((s) => s.ttsEnabled);
   const setTtsEnabled = useAppStore((s) => s.setTtsEnabled);
-  const [mobileSheet, setMobileSheet] = useState<
-    "collapsed" | "peek" | "expanded"
-  >("expanded");
+  const mobileSheet = useAppStore((s) => s.mobileSheetState);
+  const setMobileSheet = useAppStore((s) => s.setMobileSheetState);
   const [minimized, setMinimized] = useState(false);
   const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH);
   const isResizing = useRef(false);
@@ -112,14 +111,15 @@ export default function AppShell() {
   }, [activePanel]);
 
   const cycleSheet = useCallback(() => {
-    setMobileSheet((prev) =>
+    const prev = useAppStore.getState().mobileSheetState;
+    setMobileSheet(
       prev === "collapsed"
         ? "peek"
         : prev === "peek"
           ? "expanded"
           : "collapsed",
     );
-  }, []);
+  }, [setMobileSheet]);
 
   // Mobile swipe gesture for bottom sheet
   const sheetTouchStartY = useRef(0);
@@ -143,26 +143,23 @@ export default function AppShell() {
     const deltaY = sheetTouchCurrentY.current - sheetTouchStartY.current;
     const threshold = 40;
 
+    const prev = useAppStore.getState().mobileSheetState;
     if (deltaY < -threshold) {
       // Swipe up — expand
-      setMobileSheet((prev) =>
+      setMobileSheet(
         prev === "collapsed"
           ? "peek"
-          : prev === "peek"
-            ? "expanded"
-            : "expanded",
+          : "expanded",
       );
     } else if (deltaY > threshold) {
       // Swipe down — collapse
-      setMobileSheet((prev) =>
+      setMobileSheet(
         prev === "expanded"
           ? "peek"
-          : prev === "peek"
-            ? "collapsed"
-            : "collapsed",
+          : "collapsed",
       );
     }
-  }, []);
+  }, [setMobileSheet]);
 
   const toggleTts = useCallback(
     () => setTtsEnabled(!ttsEnabled),

--- a/src/components/map/EventPopup.tsx
+++ b/src/components/map/EventPopup.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useState, useRef } from "react";
-import { X, Calendar, Clock, MapPin, Navigation } from "lucide-react";
+import { useCallback, useState, useRef, useEffect } from "react";
+import { X, Calendar, Clock, MapPin, Navigation, ChevronDown, ChevronUp } from "lucide-react";
 import { useAppStore } from "@/store/app-store";
 import type { CampusEvent } from "@/types";
 
@@ -9,25 +9,64 @@ export default function EventPopup() {
   const selectedEvent = useAppStore((s) => s.selectedEvent);
   const setSelectedEvent = useAppStore((s) => s.setSelectedEvent);
   const setStreetViewEvent = useAppStore((s) => s.setStreetViewEvent);
-  const [fadingOutEvent, setFadingOutEvent] = useState<CampusEvent | null>(
-    null,
-  );
+  const mobileSheetState = useAppStore((s) => s.mobileSheetState);
+  const [fadingOutEvent, setFadingOutEvent] = useState<CampusEvent | null>(null);
+  const [cardState, setCardState] = useState<"minimized" | "expanded">("minimized");
+  const [isMobile, setIsMobile] = useState(false);
 
   const displayEvent = selectedEvent ?? fadingOutEvent;
   const isVisible = !!selectedEvent;
 
-  // Swipe-to-dismiss
+  // Detect mobile
+  useEffect(() => {
+    const mql = window.matchMedia("(max-width: 767px)");
+    setIsMobile(mql.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  // Reset to minimized when a new event is selected (mobile only)
+  useEffect(() => {
+    if (selectedEvent) {
+      setCardState(isMobile ? "minimized" : "expanded");
+    }
+  }, [selectedEvent, isMobile]);
+
+  // Swipe gesture refs
   const touchStartY = useRef(0);
   const touchCurrentY = useRef(0);
+  const innerRef = useRef<HTMLDivElement>(null);
+  const isDragging = useRef(false);
 
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
     touchStartY.current = e.touches[0].clientY;
     touchCurrentY.current = e.touches[0].clientY;
+    isDragging.current = true;
+    if (innerRef.current) {
+      innerRef.current.style.transition = "none";
+    }
   }, []);
 
-  const handleTouchMove = useCallback((e: React.TouchEvent) => {
-    touchCurrentY.current = e.touches[0].clientY;
-  }, []);
+  const handleTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (!isDragging.current) return;
+      touchCurrentY.current = e.touches[0].clientY;
+      const delta = touchCurrentY.current - touchStartY.current;
+      if (innerRef.current) {
+        if (cardState === "expanded") {
+          // Allow drag down only
+          const offset = Math.max(0, delta);
+          innerRef.current.style.transform = `translateY(${offset}px)`;
+        } else {
+          // Minimized: allow both directions with rubber-band effect
+          const offset = delta > 0 ? delta : delta * 0.4;
+          innerRef.current.style.transform = `translateY(${offset}px)`;
+        }
+      }
+    },
+    [cardState],
+  );
 
   const handleClose = useCallback(() => {
     setFadingOutEvent(useAppStore.getState().selectedEvent);
@@ -35,11 +74,39 @@ export default function EventPopup() {
   }, [setSelectedEvent]);
 
   const handleTouchEnd = useCallback(() => {
+    if (!isDragging.current) return;
+    isDragging.current = false;
     const deltaY = touchCurrentY.current - touchStartY.current;
-    if (deltaY > 60) {
-      handleClose();
+
+    if (innerRef.current) {
+      innerRef.current.style.transition = "transform 0.3s cubic-bezier(0.32, 0.72, 0, 1)";
     }
-  }, [handleClose]);
+
+    if (cardState === "expanded") {
+      if (deltaY > 80) {
+        // Swipe down on expanded → minimize
+        if (innerRef.current) innerRef.current.style.transform = "translateY(0)";
+        setCardState("minimized");
+      } else {
+        // Snap back
+        if (innerRef.current) innerRef.current.style.transform = "translateY(0)";
+      }
+    } else {
+      // Minimized
+      if (deltaY > 60) {
+        // Swipe down on minimized → dismiss with slide-out
+        if (innerRef.current) innerRef.current.style.transform = "translateY(120px)";
+        handleClose();
+      } else if (deltaY < -60) {
+        // Swipe up on minimized → expand
+        if (innerRef.current) innerRef.current.style.transform = "translateY(0)";
+        setCardState("expanded");
+      } else {
+        // Snap back
+        if (innerRef.current) innerRef.current.style.transform = "translateY(0)";
+      }
+    }
+  }, [cardState, handleClose]);
 
   const handleTransitionEnd = useCallback(() => {
     if (!useAppStore.getState().selectedEvent) {
@@ -55,130 +122,163 @@ export default function EventPopup() {
     setFadingOutEvent(null);
   }, [displayEvent, setStreetViewEvent, setSelectedEvent]);
 
+  const toggleExpand = useCallback(() => {
+    setCardState((prev) => (prev === "minimized" ? "expanded" : "minimized"));
+  }, []);
+
   if (!displayEvent) return null;
+
+  // Smart bottom positioning based on sheet state (mobile only)
+  const mobileBottomMap = { collapsed: 72, peek: 148, expanded: 148 };
+  const bottomPx = isMobile ? mobileBottomMap[mobileSheetState] : 80;
+  const isExpanded = cardState === "expanded" || !isMobile;
 
   return (
     <div
-      className={`absolute bottom-24 md:bottom-20 left-1/2 -translate-x-1/2 z-20 transition-all duration-300 ease-[cubic-bezier(0.32,0.72,0,1)] ${
+      className={`absolute left-1/2 -translate-x-1/2 z-20 transition-all duration-300 ease-[cubic-bezier(0.32,0.72,0,1)] ${
         isVisible
           ? "opacity-100 translate-y-0 scale-100"
           : "opacity-0 translate-y-6 scale-95 pointer-events-none"
       }`}
+      style={{ bottom: `${bottomPx}px` }}
       onTransitionEnd={handleTransitionEnd}
-      onTouchStart={handleTouchStart}
-      onTouchMove={handleTouchMove}
-      onTouchEnd={handleTouchEnd}
     >
-      <div className="bg-card rounded-2xl shadow-xl max-w-md w-[calc(100vw-1.5rem)] sm:w-[380px] p-5 relative border border-border">
-        <button
-          type="button"
-          onClick={handleClose}
-          className="absolute top-3 right-3 flex items-center justify-center w-9 h-9 rounded-full bg-muted hover:bg-muted/80 text-muted-foreground hover:text-foreground transition-colors"
-          aria-label="Close popup"
+      <div
+        ref={innerRef}
+        className="bg-card rounded-2xl shadow-xl max-w-md w-[calc(100vw-1.5rem)] sm:w-[380px] relative border border-border overflow-hidden"
+        style={{ touchAction: "none" }}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        {/* Drag handle — mobile only */}
+        <div
+          className="md:hidden flex flex-col items-center justify-center min-h-[28px] pt-2.5 pb-1 cursor-grab active:cursor-grabbing touch-none select-none"
+          role="button"
+          tabIndex={0}
+          aria-label={isExpanded ? "Swipe down to minimize" : "Swipe up to expand"}
+          onClick={toggleExpand}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") toggleExpand();
+          }}
         >
-          <X size={18} aria-hidden="true" />
-        </button>
+          <div className="w-10 h-1 rounded-full bg-muted-foreground/30" />
+        </div>
 
-        <div className="mb-2">
-          <span className="inline-block bg-secondary text-secondary-foreground text-sm font-semibold px-3 py-1 rounded-full">
+        {/* Minimized pill header — always visible */}
+        <div className="flex items-center gap-2.5 px-4 py-2.5 min-h-[48px]">
+          <span className="inline-block bg-secondary text-secondary-foreground text-xs font-semibold px-2.5 py-0.5 rounded-full shrink-0">
             {displayEvent.category}
           </span>
-        </div>
+          <h3 className={`font-bold text-card-foreground truncate flex-1 ${isExpanded ? "text-base" : "text-sm"}`}>
+            {displayEvent.title}
+          </h3>
 
-        <h3 className="text-xl font-bold text-card-foreground mb-1.5 pr-10">
-          {displayEvent.title}
-        </h3>
-
-        <p className="text-[0.9375rem] text-muted-foreground mb-3 line-clamp-2 leading-relaxed">
-          {displayEvent.description}
-        </p>
-
-        <div className="space-y-2 mb-4 text-[0.9375rem] text-muted-foreground">
-          <div className="flex items-start gap-2">
-            <Calendar
-              size={16}
-              className="mt-0.5 shrink-0"
-              aria-hidden="true"
-            />
-            <span className="line-clamp-1">
-              {displayEvent.date}
-              {displayEvent.endDate ? ` – ${displayEvent.endDate}` : ""}
-            </span>
-          </div>
-
-          <div className="flex items-start gap-2">
-            <Clock
-              size={16}
-              className="mt-0.5 shrink-0"
-              aria-hidden="true"
-            />
-            <span className="line-clamp-1">{displayEvent.time}</span>
-          </div>
-
-          <div className="flex items-start gap-2">
-            <MapPin
-              size={16}
-              className="mt-0.5 shrink-0"
-              aria-hidden="true"
-            />
-            <span className="line-clamp-1">{displayEvent.location}</span>
-          </div>
-
-          {displayEvent.venueAddress && (
-            <div className="flex items-start gap-2">
-              <MapPin
-                size={16}
-                className="mt-0.5 shrink-0"
-                aria-hidden="true"
-              />
-              <span className="line-clamp-1">
-                {displayEvent.venueAddress}
-              </span>
-            </div>
-          )}
-        </div>
-
-        <div className="flex gap-2 mb-4">
-          <span className="bg-secondary text-secondary-foreground text-xs px-2 py-0.5 rounded-full font-medium">
-            {displayEvent.type}
-          </span>
-          <span className="bg-muted text-muted-foreground text-xs px-2 py-0.5 rounded-full font-medium">
-            {displayEvent.school}
-          </span>
-        </div>
-
-        {displayEvent.url && displayEvent.type !== "Online" && (
-          <div className="mb-2 text-right">
-            <a
-              href={displayEvent.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-sm text-primary hover:underline font-medium"
+          {/* Expand/Collapse indicator — mobile only */}
+          {isMobile && (
+            <button
+              type="button"
+              onClick={toggleExpand}
+              className="md:hidden flex items-center justify-center w-11 h-11 -mr-1 rounded-full text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0"
+              aria-label={isExpanded ? "Collapse" : "Expand"}
             >
-              Details &rarr;
-            </a>
-          </div>
-        )}
+              {isExpanded ? <ChevronDown size={18} /> : <ChevronUp size={18} />}
+            </button>
+          )}
 
-        {displayEvent.type !== "Online" ? (
           <button
             type="button"
-            onClick={handleNavigate}
-            className="w-full bg-primary text-primary-foreground rounded-xl px-4 py-3 text-[0.9375rem] font-semibold hover:bg-primary/90 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+            onClick={handleClose}
+            className="flex items-center justify-center w-11 h-11 -mr-1 rounded-full bg-muted hover:bg-muted/80 text-muted-foreground hover:text-foreground transition-colors shrink-0"
+            aria-label="Close popup"
           >
-            <Navigation size={18} aria-hidden="true" />
-            Navigate here
+            <X size={16} aria-hidden="true" />
           </button>
-        ) : displayEvent.url ? (
-          <a
-            href={displayEvent.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="w-full bg-primary text-primary-foreground rounded-xl px-4 py-3 text-[0.9375rem] font-semibold hover:bg-primary/90 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
-          >
-            Join Online &rarr;
-          </a>
-        ) : null}
+        </div>
+
+        {/* Expandable content — smooth height animation */}
+        <div
+          className={`grid transition-[grid-template-rows] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)] ${
+            isExpanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+          }`}
+        >
+          <div className="overflow-hidden">
+            <div className="px-5 pb-5">
+              <p className="text-[0.9375rem] text-muted-foreground mb-3 line-clamp-2 leading-relaxed">
+                {displayEvent.description}
+              </p>
+
+              <div className="space-y-2 mb-4 text-[0.9375rem] text-muted-foreground">
+                <div className="flex items-start gap-2">
+                  <Calendar size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+                  <span className="line-clamp-1">
+                    {displayEvent.date}
+                    {displayEvent.endDate ? ` – ${displayEvent.endDate}` : ""}
+                  </span>
+                </div>
+
+                <div className="flex items-start gap-2">
+                  <Clock size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+                  <span className="line-clamp-1">{displayEvent.time}</span>
+                </div>
+
+                <div className="flex items-start gap-2">
+                  <MapPin size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+                  <span className="line-clamp-1">{displayEvent.location}</span>
+                </div>
+
+                {displayEvent.venueAddress && (
+                  <div className="flex items-start gap-2">
+                    <MapPin size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+                    <span className="line-clamp-1">{displayEvent.venueAddress}</span>
+                  </div>
+                )}
+              </div>
+
+              <div className="flex gap-2 mb-4">
+                <span className="bg-secondary text-secondary-foreground text-xs px-2 py-0.5 rounded-full font-medium">
+                  {displayEvent.type}
+                </span>
+                <span className="bg-muted text-muted-foreground text-xs px-2 py-0.5 rounded-full font-medium">
+                  {displayEvent.school}
+                </span>
+              </div>
+
+              {displayEvent.url && displayEvent.type !== "Online" && (
+                <div className="mb-2 text-right">
+                  <a
+                    href={displayEvent.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-primary hover:underline font-medium"
+                  >
+                    Details &rarr;
+                  </a>
+                </div>
+              )}
+
+              {displayEvent.type !== "Online" ? (
+                <button
+                  type="button"
+                  onClick={handleNavigate}
+                  className="w-full bg-primary text-primary-foreground rounded-xl px-4 py-3 min-h-[44px] text-[0.9375rem] font-semibold hover:bg-primary/90 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+                >
+                  <Navigation size={18} aria-hidden="true" />
+                  Navigate here
+                </button>
+              ) : displayEvent.url ? (
+                <a
+                  href={displayEvent.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="w-full bg-primary text-primary-foreground rounded-xl px-4 py-3 min-h-[44px] text-[0.9375rem] font-semibold hover:bg-primary/90 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+                >
+                  Join Online &rarr;
+                </a>
+              ) : null}
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/map/POIPopup.tsx
+++ b/src/components/map/POIPopup.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useState, useMemo, useRef } from "react";
-import { X, MapPin, Clock, Star, Navigation, Calendar } from "lucide-react";
+import { useCallback, useState, useMemo, useRef, useEffect } from "react";
+import { X, MapPin, Clock, Star, Navigation, Calendar, ChevronDown, ChevronUp } from "lucide-react";
 import { useAppStore } from "@/store/app-store";
 import type { POI } from "@/types";
 import campusEvents from "@/../public/campus-events.json";
@@ -27,7 +27,10 @@ export default function POIPopup() {
   const setStreetViewEvent = useAppStore((s) => s.setStreetViewEvent);
   const setSelectedEvent = useAppStore((s) => s.setSelectedEvent);
   const setActivePanel = useAppStore((s) => s.setActivePanel);
+  const mobileSheetState = useAppStore((s) => s.mobileSheetState);
   const [fadingOutPOI, setFadingOutPOI] = useState<POI | null>(null);
+  const [cardState, setCardState] = useState<"minimized" | "expanded">("minimized");
+  const [isMobile, setIsMobile] = useState(false);
 
   const displayPOI = selectedPOI ?? fadingOutPOI;
   const isVisible = !!selectedPOI;
@@ -37,18 +40,54 @@ export default function POIPopup() {
     [displayPOI],
   );
 
-  // Swipe-to-dismiss
+  // Detect mobile
+  useEffect(() => {
+    const mql = window.matchMedia("(max-width: 767px)");
+    setIsMobile(mql.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  // Reset to minimized when a new POI is selected (mobile only)
+  useEffect(() => {
+    if (selectedPOI) {
+      setCardState(isMobile ? "minimized" : "expanded");
+    }
+  }, [selectedPOI, isMobile]);
+
+  // Swipe gesture refs
   const touchStartY = useRef(0);
   const touchCurrentY = useRef(0);
+  const innerRef = useRef<HTMLDivElement>(null);
+  const isDragging = useRef(false);
 
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
     touchStartY.current = e.touches[0].clientY;
     touchCurrentY.current = e.touches[0].clientY;
+    isDragging.current = true;
+    if (innerRef.current) {
+      innerRef.current.style.transition = "none";
+    }
   }, []);
 
-  const handleTouchMove = useCallback((e: React.TouchEvent) => {
-    touchCurrentY.current = e.touches[0].clientY;
-  }, []);
+  const handleTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (!isDragging.current) return;
+      touchCurrentY.current = e.touches[0].clientY;
+      const delta = touchCurrentY.current - touchStartY.current;
+      if (innerRef.current) {
+        if (cardState === "expanded") {
+          const offset = Math.max(0, delta);
+          innerRef.current.style.transform = `translateY(${offset}px)`;
+        } else {
+          const offset = delta > 0 ? delta : delta * 0.4;
+          innerRef.current.style.transform = `translateY(${offset}px)`;
+        }
+      }
+    },
+    [cardState],
+  );
 
   const handleClose = useCallback(() => {
     setFadingOutPOI(useAppStore.getState().selectedPOI);
@@ -56,11 +95,34 @@ export default function POIPopup() {
   }, [setSelectedPOI]);
 
   const handleTouchEnd = useCallback(() => {
+    if (!isDragging.current) return;
+    isDragging.current = false;
     const deltaY = touchCurrentY.current - touchStartY.current;
-    if (deltaY > 60) {
-      handleClose();
+
+    if (innerRef.current) {
+      innerRef.current.style.transition = "transform 0.3s cubic-bezier(0.32, 0.72, 0, 1)";
     }
-  }, [handleClose]);
+
+    if (cardState === "expanded") {
+      if (deltaY > 80) {
+        if (innerRef.current) innerRef.current.style.transform = "translateY(0)";
+        setCardState("minimized");
+      } else {
+        if (innerRef.current) innerRef.current.style.transform = "translateY(0)";
+      }
+    } else {
+      if (deltaY > 60) {
+        // Dismiss with slide-out animation
+        if (innerRef.current) innerRef.current.style.transform = "translateY(120px)";
+        handleClose();
+      } else if (deltaY < -60) {
+        if (innerRef.current) innerRef.current.style.transform = "translateY(0)";
+        setCardState("expanded");
+      } else {
+        if (innerRef.current) innerRef.current.style.transform = "translateY(0)";
+      }
+    }
+  }, [cardState, handleClose]);
 
   const handleTransitionEnd = useCallback(() => {
     if (!useAppStore.getState().selectedPOI) {
@@ -99,113 +161,150 @@ export default function POIPopup() {
     [setSelectedPOI, setSelectedEvent, setActivePanel],
   );
 
+  const toggleExpand = useCallback(() => {
+    setCardState((prev) => (prev === "minimized" ? "expanded" : "minimized"));
+  }, []);
+
   if (!displayPOI) return null;
+
+  const mobileBottomMap = { collapsed: 72, peek: 148, expanded: 148 };
+  const bottomPx = isMobile ? mobileBottomMap[mobileSheetState] : 80;
+  const isExpanded = cardState === "expanded" || !isMobile;
 
   return (
     <div
-      className={`absolute bottom-24 md:bottom-20 left-1/2 -translate-x-1/2 z-20 transition-all duration-300 ease-[cubic-bezier(0.32,0.72,0,1)] ${
+      className={`absolute left-1/2 -translate-x-1/2 z-20 transition-all duration-300 ease-[cubic-bezier(0.32,0.72,0,1)] ${
         isVisible
           ? "opacity-100 translate-y-0 scale-100"
           : "opacity-0 translate-y-6 scale-95 pointer-events-none"
       }`}
+      style={{ bottom: `${bottomPx}px` }}
       onTransitionEnd={handleTransitionEnd}
-      onTouchStart={handleTouchStart}
-      onTouchMove={handleTouchMove}
-      onTouchEnd={handleTouchEnd}
     >
-      <div className="bg-card rounded-2xl shadow-xl max-w-md w-[calc(100vw-1.5rem)] sm:w-[380px] p-5 relative border border-border">
-        <button
-          type="button"
-          onClick={handleClose}
-          className="absolute top-3 right-3 flex items-center justify-center w-9 h-9 rounded-full bg-muted hover:bg-muted/80 text-muted-foreground hover:text-foreground transition-colors"
-          aria-label="Close popup"
+      <div
+        ref={innerRef}
+        className="bg-card rounded-2xl shadow-xl max-w-md w-[calc(100vw-1.5rem)] sm:w-[380px] relative border border-border overflow-hidden"
+        style={{ touchAction: "none" }}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        {/* Drag handle — mobile only */}
+        <div
+          className="md:hidden flex flex-col items-center justify-center min-h-[28px] pt-2.5 pb-1 cursor-grab active:cursor-grabbing touch-none select-none"
+          role="button"
+          tabIndex={0}
+          aria-label={isExpanded ? "Swipe down to minimize" : "Swipe up to expand"}
+          onClick={toggleExpand}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") toggleExpand();
+          }}
         >
-          <X size={18} aria-hidden="true" />
-        </button>
+          <div className="w-10 h-1 rounded-full bg-muted-foreground/30" />
+        </div>
 
-        <div className="mb-2">
-          <span className="inline-block bg-secondary text-secondary-foreground text-sm font-semibold px-3 py-1 rounded-full">
+        {/* Minimized pill header — always visible */}
+        <div className="flex items-center gap-2.5 px-4 py-2.5 min-h-[48px]">
+          <span className="inline-block bg-secondary text-secondary-foreground text-xs font-semibold px-2.5 py-0.5 rounded-full shrink-0">
             {displayPOI.category}
           </span>
+          <h3 className={`font-bold text-card-foreground truncate flex-1 ${isExpanded ? "text-base" : "text-sm"}`}>
+            {displayPOI.name}
+          </h3>
+
+          {isMobile && (
+            <button
+              type="button"
+              onClick={toggleExpand}
+              className="md:hidden flex items-center justify-center w-11 h-11 -mr-1 rounded-full text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0"
+              aria-label={isExpanded ? "Collapse" : "Expand"}
+            >
+              {isExpanded ? <ChevronDown size={18} /> : <ChevronUp size={18} />}
+            </button>
+          )}
+
+          <button
+            type="button"
+            onClick={handleClose}
+            className="flex items-center justify-center w-11 h-11 -mr-1 rounded-full bg-muted hover:bg-muted/80 text-muted-foreground hover:text-foreground transition-colors shrink-0"
+            aria-label="Close popup"
+          >
+            <X size={16} aria-hidden="true" />
+          </button>
         </div>
 
-        <h3 className="text-xl font-bold text-card-foreground mb-1.5 pr-10">
-          {displayPOI.name}
-        </h3>
+        {/* Expandable content */}
+        <div
+          className={`grid transition-[grid-template-rows] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)] ${
+            isExpanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+          }`}
+        >
+          <div className="overflow-hidden">
+            <div className="px-5 pb-5">
+              <p className="text-[0.9375rem] text-muted-foreground mb-3 line-clamp-2 leading-relaxed">
+                {displayPOI.description}
+              </p>
 
-        <p className="text-[0.9375rem] text-muted-foreground mb-3 line-clamp-2 leading-relaxed">
-          {displayPOI.description}
-        </p>
+              <div className="space-y-2 mb-4 text-[0.9375rem] text-muted-foreground">
+                {displayPOI.address && (
+                  <div className="flex items-start gap-2">
+                    <MapPin size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+                    <span className="line-clamp-1">{displayPOI.address}</span>
+                  </div>
+                )}
 
-        <div className="space-y-2 mb-4 text-[0.9375rem] text-muted-foreground">
-          {displayPOI.address && (
-            <div className="flex items-start gap-2">
-              <MapPin
-                size={16}
-                className="mt-0.5 shrink-0"
-                aria-hidden="true"
-              />
-              <span className="line-clamp-1">{displayPOI.address}</span>
-            </div>
-          )}
+                {displayPOI.hours && (
+                  <div className="flex items-start gap-2">
+                    <Clock size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+                    <span className="line-clamp-1">{displayPOI.hours}</span>
+                  </div>
+                )}
 
-          {displayPOI.hours && (
-            <div className="flex items-start gap-2">
-              <Clock
-                size={16}
-                className="mt-0.5 shrink-0"
-                aria-hidden="true"
-              />
-              <span className="line-clamp-1">{displayPOI.hours}</span>
-            </div>
-          )}
+                {displayPOI.rating && (
+                  <div className="flex items-center gap-2">
+                    <Star size={16} className="text-yellow-500 fill-yellow-500 shrink-0" aria-hidden="true" />
+                    <span>{displayPOI.rating} / 5.0</span>
+                  </div>
+                )}
+              </div>
 
-          {displayPOI.rating && (
-            <div className="flex items-center gap-2">
-              <Star
-                size={16}
-                className="text-yellow-500 fill-yellow-500 shrink-0"
-                aria-hidden="true"
-              />
-              <span>{displayPOI.rating} / 5.0</span>
-            </div>
-          )}
-        </div>
+              {nearbyEvents.length > 0 && (
+                <div className="mb-3 border-t border-border pt-3">
+                  <p className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2 flex items-center gap-1.5">
+                    <Calendar size={14} aria-hidden="true" />
+                    Upcoming Events Nearby
+                  </p>
+                  <div className="space-y-1.5">
+                    {nearbyEvents.map((evt) => (
+                      <button
+                        key={evt.id}
+                        type="button"
+                        onClick={() => handleEventClick(evt)}
+                        className="w-full text-left flex items-center gap-2.5 bg-secondary/50 border border-secondary rounded-lg px-3.5 py-2.5 min-h-[44px] hover:bg-secondary/80 active:bg-secondary transition-colors"
+                      >
+                        <span className="text-primary text-sm font-medium shrink-0">
+                          {evt.date}
+                        </span>
+                        <span className="text-sm text-card-foreground truncate">
+                          {evt.title}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
 
-        {nearbyEvents.length > 0 && (
-          <div className="mb-3 border-t border-border pt-3">
-            <p className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2 flex items-center gap-1.5">
-              <Calendar size={14} aria-hidden="true" />
-              Upcoming Events Nearby
-            </p>
-            <div className="space-y-1.5">
-              {nearbyEvents.map((evt) => (
-                <button
-                  key={evt.id}
-                  type="button"
-                  onClick={() => handleEventClick(evt)}
-                  className="w-full text-left flex items-center gap-2.5 bg-secondary/50 border border-secondary rounded-lg px-3.5 py-2.5 min-h-[44px] hover:bg-secondary/80 active:bg-secondary transition-colors"
-                >
-                  <span className="text-primary text-sm font-medium shrink-0">
-                    {evt.date}
-                  </span>
-                  <span className="text-sm text-card-foreground truncate">
-                    {evt.title}
-                  </span>
-                </button>
-              ))}
+              <button
+                type="button"
+                onClick={handleNavigate}
+                className="w-full bg-surface-brand text-surface-brand-foreground rounded-xl px-4 py-3 min-h-[44px] text-[0.9375rem] font-semibold hover:bg-surface-brand/90 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+              >
+                <Navigation size={18} aria-hidden="true" />
+                Navigate here
+              </button>
             </div>
           </div>
-        )}
-
-        <button
-          type="button"
-          onClick={handleNavigate}
-          className="w-full bg-surface-brand text-surface-brand-foreground rounded-xl px-4 py-3 text-[0.9375rem] font-semibold hover:bg-surface-brand/90 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
-        >
-          <Navigation size={18} aria-hidden="true" />
-          Navigate here
-        </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/ui/POICard.tsx
+++ b/src/components/ui/POICard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import {
   MapPin,
   Clock,
@@ -9,6 +9,8 @@ import {
   ExternalLink,
   Phone,
   Tag,
+  ChevronDown,
+  ChevronUp,
 } from "lucide-react";
 import { useAppStore } from "@/store/app-store";
 import type { POI } from "@/types";
@@ -25,13 +27,9 @@ function priceLevelToLabel(level: number): string {
 export default function POICard({ poi }: POICardProps) {
   const setFlyToTarget = useAppStore((s) => s.setFlyToTarget);
   const setSelectedPOI = useAppStore((s) => s.setSelectedPOI);
+  const [isExpanded, setIsExpanded] = useState(false);
 
-  const handleCardClick = useCallback(() => {
-    setFlyToTarget({ lat: poi.lat, lng: poi.lng });
-    setSelectedPOI(poi);
-  }, [poi, setFlyToTarget, setSelectedPOI]);
-
-  const handleNavigate = useCallback(
+  const handleShowOnMap = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
       setFlyToTarget({ lat: poi.lat, lng: poi.lng });
@@ -40,112 +38,131 @@ export default function POICard({ poi }: POICardProps) {
     [poi, setFlyToTarget, setSelectedPOI],
   );
 
+  const toggleExpand = useCallback(() => {
+    setIsExpanded((prev) => !prev);
+  }, []);
+
   return (
-    <div className="relative bg-card rounded-2xl shadow-lg border border-border w-full text-left p-5 transition-all hover:shadow-xl hover:border-border/80">
+    <div className="relative bg-card rounded-2xl shadow-lg border border-border w-full text-left transition-all hover:shadow-xl hover:border-border/80 overflow-hidden">
+      {/* Collapsed header — always visible, tappable to expand */}
       <button
         type="button"
-        onClick={handleCardClick}
-        className="absolute inset-0 z-10 rounded-2xl cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        aria-label={`Select ${poi.name} and fly to location`}
-      />
-
-      <div className="flex items-center gap-2 mb-2 flex-wrap">
-        <span className="inline-block bg-secondary text-secondary-foreground text-sm font-semibold px-3 py-1 rounded-full">
-          {poi.category}
-        </span>
-        {poi.distanceFromCampus && (
-          <Badge variant="outline" className="text-xs text-muted-foreground">
-            {poi.distanceFromCampus}
-          </Badge>
-        )}
-        {poi.priceLevel && (
-          <span className="text-sm font-medium text-muted-foreground">
-            {priceLevelToLabel(poi.priceLevel)}
+        onClick={toggleExpand}
+        className="w-full text-left flex items-center gap-3 p-4 min-h-[56px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+        aria-expanded={isExpanded}
+        aria-label={`${poi.name} — tap to ${isExpanded ? "collapse" : "expand"}`}
+      >
+        <div className="flex items-center gap-2 flex-wrap flex-1 min-w-0">
+          <span className="inline-block bg-secondary text-secondary-foreground text-xs font-semibold px-2.5 py-0.5 rounded-full shrink-0">
+            {poi.category}
           </span>
-        )}
-      </div>
-
-      <h3 className="text-lg font-bold text-card-foreground mb-1.5">
-        {poi.name}
-      </h3>
-
-      <p className="text-[0.9375rem] text-muted-foreground mb-3 line-clamp-2 leading-relaxed">
-        {poi.description}
-      </p>
-
-      <div className="space-y-2 mb-4 text-[0.9375rem] text-muted-foreground">
-        {poi.address && (
-          <div className="flex items-start gap-2">
-            <MapPin size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
-            <span className="line-clamp-1">{poi.address}</span>
-          </div>
-        )}
-
-        {poi.hours && (
-          <div className="flex items-start gap-2">
-            <Clock size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
-            <span className="line-clamp-1">{poi.hours}</span>
-          </div>
-        )}
-
-        {poi.rating && (
-          <div className="flex items-center gap-2">
-            <Star
-              size={16}
-              className="text-yellow-500 fill-yellow-500 shrink-0"
-              aria-hidden="true"
-            />
-            <span>{poi.rating} / 5.0</span>
-          </div>
-        )}
-
-        {poi.contact && (
-          <div className="flex items-center gap-2">
-            <Phone size={16} className="shrink-0" aria-hidden="true" />
-            <span>{poi.contact}</span>
-          </div>
-        )}
-      </div>
-
-      {poi.tags && poi.tags.length > 0 && (
-        <div className="flex items-center gap-1.5 mb-4 flex-wrap">
-          <Tag
-            size={14}
-            className="text-muted-foreground shrink-0"
-            aria-hidden="true"
-          />
-          {poi.tags.map((tag) => (
-            <span
-              key={tag}
-              className="inline-block bg-muted text-muted-foreground text-xs px-2 py-0.5 rounded-full"
-            >
-              {tag}
+          <h3 className="text-sm font-bold text-card-foreground truncate">
+            {poi.name}
+          </h3>
+          {poi.distanceFromCampus && (
+            <Badge variant="outline" className="text-[0.6875rem] text-muted-foreground shrink-0">
+              {poi.distanceFromCampus}
+            </Badge>
+          )}
+          {poi.priceLevel && (
+            <span className="text-xs font-medium text-muted-foreground shrink-0">
+              {priceLevelToLabel(poi.priceLevel)}
             </span>
-          ))}
+          )}
         </div>
-      )}
+        <div className="flex items-center justify-center w-7 h-7 rounded-full text-muted-foreground shrink-0">
+          {isExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+        </div>
+      </button>
 
-      <div className="relative z-20 flex items-center gap-2 pt-3 border-t border-border">
-        <button
-          type="button"
-          onClick={handleNavigate}
-          className="flex-1 bg-surface-brand text-surface-brand-foreground rounded-xl px-4 py-3 min-h-[44px] text-[0.9375rem] font-semibold hover:bg-surface-brand/90 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
-        >
-          <Navigation size={16} aria-hidden="true" />
-          Navigate here
-        </button>
-        {poi.website && (
-          <a
-            href={poi.website}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={(e) => e.stopPropagation()}
-            className="relative z-20 inline-flex items-center gap-1.5 rounded-xl border border-border px-4 py-3 min-h-[44px] text-[0.9375rem] font-semibold text-card-foreground hover:bg-muted active:scale-[0.98] transition-all"
-          >
-            <ExternalLink size={16} aria-hidden="true" />
-            Website
-          </a>
-        )}
+      {/* Expandable details */}
+      <div
+        className={`grid transition-[grid-template-rows] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)] ${
+          isExpanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+        }`}
+      >
+        <div className="overflow-hidden">
+          <div className="px-5 pb-5">
+            <p className="text-[0.9375rem] text-muted-foreground mb-3 line-clamp-3 leading-relaxed">
+              {poi.description}
+            </p>
+
+            <div className="space-y-2 mb-4 text-[0.9375rem] text-muted-foreground">
+              {poi.address && (
+                <div className="flex items-start gap-2">
+                  <MapPin size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+                  <span className="line-clamp-1">{poi.address}</span>
+                </div>
+              )}
+
+              {poi.hours && (
+                <div className="flex items-start gap-2">
+                  <Clock size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+                  <span className="line-clamp-1">{poi.hours}</span>
+                </div>
+              )}
+
+              {poi.rating && (
+                <div className="flex items-center gap-2">
+                  <Star
+                    size={16}
+                    className="text-yellow-500 fill-yellow-500 shrink-0"
+                    aria-hidden="true"
+                  />
+                  <span>{poi.rating} / 5.0</span>
+                </div>
+              )}
+
+              {poi.contact && (
+                <div className="flex items-center gap-2">
+                  <Phone size={16} className="shrink-0" aria-hidden="true" />
+                  <span>{poi.contact}</span>
+                </div>
+              )}
+            </div>
+
+            {poi.tags && poi.tags.length > 0 && (
+              <div className="flex items-center gap-1.5 mb-4 flex-wrap">
+                <Tag
+                  size={14}
+                  className="text-muted-foreground shrink-0"
+                  aria-hidden="true"
+                />
+                {poi.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="inline-block bg-muted text-muted-foreground text-xs px-2 py-0.5 rounded-full"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            <div className="flex items-center gap-2 pt-3 border-t border-border">
+              <button
+                type="button"
+                onClick={handleShowOnMap}
+                className="flex-1 bg-surface-brand text-surface-brand-foreground rounded-xl px-4 py-3 min-h-[44px] text-[0.9375rem] font-semibold hover:bg-surface-brand/90 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+              >
+                <Navigation size={16} aria-hidden="true" />
+                Show on map
+              </button>
+              {poi.website && (
+                <a
+                  href={poi.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                  className="inline-flex items-center gap-1.5 rounded-xl border border-border px-4 py-3 min-h-[44px] text-[0.9375rem] font-semibold text-card-foreground hover:bg-muted active:scale-[0.98] transition-all"
+                >
+                  <ExternalLink size={16} aria-hidden="true" />
+                  Website
+                </a>
+              )}
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/ui/VenueCard.tsx
+++ b/src/components/ui/VenueCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useCallback } from "react";
 import {
   MapPin,
   Clock,
@@ -14,6 +15,8 @@ import {
   ShoppingBag,
   ShoppingCart,
   Footprints,
+  ChevronDown,
+  ChevronUp,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -50,15 +53,24 @@ function renderPriceLevel(level: PriceLevel): string {
 export default function VenueCard({ venue }: VenueCardProps) {
   const setFlyToTarget = useAppStore((s) => s.setFlyToTarget);
   const setSelectedPOI = useAppStore((s) => s.setSelectedPOI);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   const CategoryIcon = categoryIconMap[venue.category] ?? MapPin;
   const iconColors =
     categoryColorMap[venue.category] ?? "bg-muted text-muted-foreground";
 
-  function handleCardClick() {
-    setFlyToTarget({ lat: venue.lat, lng: venue.lng });
-    setSelectedPOI(venue);
-  }
+  const toggleExpand = useCallback(() => {
+    setIsExpanded((prev) => !prev);
+  }, []);
+
+  const handleShowOnMap = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setFlyToTarget({ lat: venue.lat, lng: venue.lng });
+      setSelectedPOI(venue);
+    },
+    [venue, setFlyToTarget, setSelectedPOI],
+  );
 
   function handleNavigate(e: React.MouseEvent) {
     e.stopPropagation();
@@ -81,12 +93,15 @@ export default function VenueCard({ venue }: VenueCardProps) {
   }
 
   return (
-    <button
-      type="button"
-      onClick={handleCardClick}
-      className="group w-full text-left rounded-xl border border-border bg-card p-3.5 transition-all duration-150 hover:shadow-md hover:border-primary/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-    >
-      <div className="flex gap-3">
+    <div className="w-full rounded-xl border border-border bg-card transition-all duration-150 hover:shadow-md hover:border-primary/30 overflow-hidden">
+      {/* Collapsed header — always visible */}
+      <button
+        type="button"
+        onClick={toggleExpand}
+        className="group w-full text-left flex items-center gap-3 p-3.5 min-h-[56px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+        aria-expanded={isExpanded}
+        aria-label={`${venue.name} — tap to ${isExpanded ? "collapse" : "expand"}`}
+      >
         <div
           className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-xl ${iconColors}`}
         >
@@ -136,62 +151,99 @@ export default function VenueCard({ venue }: VenueCardProps) {
               </span>
             )}
           </div>
+        </div>
 
-          {venue.hours && (
-            <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
-              <Clock size={11} className="shrink-0" aria-hidden="true" />
-              <span className="truncate">{venue.hours}</span>
-            </div>
-          )}
+        <div className="flex items-center justify-center w-7 h-7 rounded-full text-muted-foreground shrink-0">
+          {isExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+        </div>
+      </button>
 
-          {venue.tags && venue.tags.length > 0 && (
-            <div className="mt-1.5 flex flex-wrap gap-1">
-              {venue.tags.map((tag) => (
-                <Badge
-                  key={tag}
-                  variant="secondary"
-                  className="px-1.5 py-0 text-[0.625rem] leading-4"
+      {/* Expandable details */}
+      <div
+        className={`grid transition-[grid-template-rows] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)] ${
+          isExpanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+        }`}
+      >
+        <div className="overflow-hidden">
+          <div className="px-3.5 pb-3.5 pt-0">
+            {venue.description && (
+              <p className="text-[0.8125rem] text-muted-foreground mb-2.5 line-clamp-3 leading-relaxed">
+                {venue.description}
+              </p>
+            )}
+
+            {venue.hours && (
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-2">
+                <Clock size={12} className="shrink-0" aria-hidden="true" />
+                <span className="truncate">{venue.hours}</span>
+              </div>
+            )}
+
+            {venue.address && (
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-2">
+                <MapPin size={12} className="shrink-0" aria-hidden="true" />
+                <span className="truncate">{venue.address}</span>
+              </div>
+            )}
+
+            {venue.tags && venue.tags.length > 0 && (
+              <div className="flex flex-wrap gap-1 mb-3">
+                {venue.tags.map((tag) => (
+                  <Badge
+                    key={tag}
+                    variant="secondary"
+                    className="px-1.5 py-0 text-[0.625rem] leading-4"
+                  >
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            )}
+
+            <div className="flex items-center gap-1.5 pt-2.5 border-t border-border">
+              <button
+                type="button"
+                onClick={handleShowOnMap}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-surface-brand px-3.5 py-2 min-h-[44px] text-xs font-semibold text-surface-brand-foreground transition-colors hover:bg-surface-brand-hover active:scale-[0.97] flex-1 justify-center"
+              >
+                <MapPin size={14} aria-hidden="true" />
+                Show on map
+              </button>
+
+              <button
+                type="button"
+                onClick={handleNavigate}
+                className="inline-flex items-center gap-1 rounded-lg border border-border px-3 py-2 min-h-[44px] text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.97]"
+              >
+                <Navigation size={12} aria-hidden="true" />
+                Navigate
+              </button>
+
+              {venue.contact && (
+                <button
+                  type="button"
+                  onClick={handleCall}
+                  className="inline-flex items-center justify-center rounded-lg border border-border w-[44px] h-[44px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.97]"
+                  aria-label="Call"
                 >
-                  {tag}
-                </Badge>
-              ))}
+                  <Phone size={14} aria-hidden="true" />
+                </button>
+              )}
+
+              {venue.website && (
+                <button
+                  type="button"
+                  onClick={handleWebsite}
+                  className="inline-flex items-center justify-center rounded-lg border border-border w-[44px] h-[44px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.97]"
+                  aria-label="Website"
+                >
+                  <ExternalLink size={14} aria-hidden="true" />
+                </button>
+              )}
             </div>
-          )}
-
-          <div className="mt-2.5 flex items-center gap-1.5">
-            <button
-              type="button"
-              onClick={handleNavigate}
-              className="inline-flex items-center gap-1 rounded-lg bg-surface-brand px-3 py-1.5 min-h-[36px] text-xs font-medium text-surface-brand-foreground transition-colors hover:bg-surface-brand-hover active:scale-[0.97]"
-            >
-              <Navigation size={12} aria-hidden="true" />
-              Navigate
-            </button>
-
-            {venue.contact && (
-              <button
-                type="button"
-                onClick={handleCall}
-                className="inline-flex items-center gap-1 rounded-lg border border-border px-2.5 py-1.5 min-h-[36px] text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.97]"
-              >
-                <Phone size={12} aria-hidden="true" />
-                Call
-              </button>
-            )}
-
-            {venue.website && (
-              <button
-                type="button"
-                onClick={handleWebsite}
-                className="inline-flex items-center gap-1 rounded-lg border border-border px-2.5 py-1.5 min-h-[36px] text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.97]"
-              >
-                <ExternalLink size={12} aria-hidden="true" />
-                Web
-              </button>
-            )}
           </div>
         </div>
       </div>
-    </button>
+    </div>
   );
 }

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -45,6 +45,9 @@ interface AppState {
 
   pendingChatMessage: string | null;
   setPendingChatMessage: (message: string | null) => void;
+
+  mobileSheetState: "collapsed" | "peek" | "expanded";
+  setMobileSheetState: (state: "collapsed" | "peek" | "expanded") => void;
 }
 
 function generateId(): string {
@@ -55,7 +58,11 @@ export const useAppStore = create<AppState>()(
   persist(
     (set) => ({
       selectedPOI: null,
-      setSelectedPOI: (poi) => set({ selectedPOI: poi, selectedEvent: null }),
+      setSelectedPOI: (poi) => set((state) => ({
+        selectedPOI: poi,
+        selectedEvent: null,
+        ...(poi && state.mobileSheetState === "expanded" ? { mobileSheetState: "peek" as const } : {}),
+      })),
       selectedDestination: null,
       setSelectedDestination: (poi) => set({ selectedDestination: poi }),
       routeInfo: null,
@@ -75,7 +82,11 @@ export const useAppStore = create<AppState>()(
       highlightedEventIds: [],
       setHighlightedEventIds: (ids) => set({ highlightedEventIds: ids }),
       selectedEvent: null,
-      setSelectedEvent: (event) => set({ selectedEvent: event, selectedPOI: null }),
+      setSelectedEvent: (event) => set((state) => ({
+        selectedEvent: event,
+        selectedPOI: null,
+        ...(event && state.mobileSheetState === "expanded" ? { mobileSheetState: "peek" as const } : {}),
+      })),
       streetViewEvent: null,
       setStreetViewEvent: (event) => set({ streetViewEvent: event }),
 
@@ -101,6 +112,9 @@ export const useAppStore = create<AppState>()(
 
       pendingChatMessage: null,
       setPendingChatMessage: (message) => set({ pendingChatMessage: message }),
+
+      mobileSheetState: "expanded",
+      setMobileSheetState: (state) => set({ mobileSheetState: state }),
     }),
     {
       name: "asksussi-prefs",


### PR DESCRIPTION
## Minimizable & Expandable Info Cards

Transform map popups into collapsible mobile-friendly cards:

### Changes
- **EventPopup & POIPopup**: Minimize to compact pill bar (title + category), tap to expand full details, swipe-down-to-dismiss with drag handle
- **AppShell**: Exposed mobileSheet state to store for popup coordination, auto-collapse sheet when popup opens
- **POICard & VenueCard**: Added expand/collapse for long descriptions, prominent 'Show on map' buttons
- **app-store**: New mobileSheetState + setMobileSheetState for cross-component coordination

### Stats
- 7 files changed, +665 / -494 lines
- Smart positioning: popups always above bottom sheet
- All touch targets ≥44px
- Swipe gesture thresholds tuned for mobile

No business logic changes. UI/UX only.