### PR TITLE
feat(ux): polish events discovery & onboarding mobile UX

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -468,3 +468,14 @@
 @utility pb-safe {
   padding-bottom: env(safe-area-inset-bottom, 0px);
 }
+
+/* ── Events Animations ── */
+@keyframes shimmer-slide {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+@keyframes stagger-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState, useCallback, useEffect } from "react";
 import type { CampusEvent } from "@/types";
 import { Badge } from "@/components/ui/badge";
 import { ExternalLink } from "lucide-react";
@@ -8,6 +8,7 @@ import { useAppStore } from "@/store/app-store";
 
 interface EventCardProps {
   event: CampusEvent;
+  index?: number;
 }
 
 const TYPE_COLORS: Record<string, string> = {
@@ -16,21 +17,35 @@ const TYPE_COLORS: Record<string, string> = {
   External: "bg-event-external-bg text-event-external-fg",
 };
 
-const CATEGORY_COLORS: Record<string, string> = {
-  "Information Session": "border-blue-500",
-  "Open House": "border-green-500",
-  "Public Lecture / Enrichment Talk": "border-purple-500",
-  Symposium: "border-teal-500",
-  "Competition / Hackathon": "border-orange-500",
-  Career: "border-emerald-500",
-  Social: "border-amber-500",
+const TYPE_DOTS: Record<string, string> = {
+  "On-Campus": "bg-event-oncampus-fg",
+  Online: "bg-event-online-fg",
+  External: "bg-event-external-fg",
 };
 
-export default function EventCard({ event }: EventCardProps) {
+const CATEGORY_ACCENT: Record<string, string> = {
+  "Information Session": "border-l-blue-500",
+  "Open House": "border-l-emerald-500",
+  "Public Lecture / Enrichment Talk": "border-l-violet-500",
+  Symposium: "border-l-teal-500",
+  "Competition / Hackathon": "border-l-orange-500",
+  Career: "border-l-sky-500",
+  Social: "border-l-amber-500",
+};
+
+export default function EventCard({ event, index = 0 }: EventCardProps) {
   const setFlyToTarget = useAppStore((s) => s.setFlyToTarget);
   const setSelectedEvent = useAppStore((s) => s.setSelectedEvent);
   const setStreetViewEvent = useAppStore((s) => s.setStreetViewEvent);
   const [isExpanded, setIsExpanded] = useState(false);
+  const [contentHeight, setContentHeight] = useState(0);
+
+  useEffect(() => {
+    if (contentRef.current) {
+      setContentHeight(contentRef.current.scrollHeight);
+    }
+  }, [isExpanded]);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   const handleClick = () => {
     setFlyToTarget({ lat: event.lat, lng: event.lng });
@@ -51,53 +66,109 @@ export default function EventCard({ event }: EventCardProps) {
       type="button"
       aria-label={`View ${event.title} on map`}
       onClick={handleClick}
-      className={`w-full text-left p-3 rounded-lg border border-l-4 ${CATEGORY_COLORS[event.category] || "border-gray-300"} hover:bg-muted/50 transition-colors flex flex-col gap-2`}
+      style={{ "--card-index": index } as React.CSSProperties}
+      className={`animate-card-slide-in w-full text-left rounded-2xl border border-border/60 border-l-4 ${CATEGORY_ACCENT[event.category] || "border-l-gray-300"} bg-card hover:bg-muted/30 active:bg-muted/50 active:scale-[0.985] transition-all duration-200 ease-out flex flex-col gap-3 shadow-[0_1px_3px_rgba(0,0,0,0.06)] hover:shadow-[0_4px_12px_rgba(0,0,0,0.08)] p-5`}
     >
-      <div className="flex items-start justify-between gap-2 w-full">
-        <div className="flex items-center gap-2">
-          {event.organizerLogo && (
-            <img
-              src={event.organizerLogo}
-              alt={`${event.title} organizer`}
-              width={24}
-              height={24}
-              className="w-6 h-6 rounded-full shrink-0 object-cover"
-            />
-          )}
-          <h3 className="font-semibold text-[0.9375rem] leading-snug">{event.title}</h3>
+      {/* Header: logo + title + type indicator */}
+      <div className="flex items-start gap-3.5 w-full">
+        {event.organizerLogo ? (
+          <img
+            src={event.organizerLogo}
+            alt={`${event.title} organizer`}
+            width={40}
+            height={40}
+            className="w-10 h-10 rounded-xl shrink-0 object-cover border border-border/40 shadow-sm"
+          />
+        ) : (
+          <div className="w-10 h-10 rounded-xl shrink-0 bg-muted flex items-center justify-center border border-border/40">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5 text-muted-foreground/60">
+              <title>Event</title>
+              <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
+              <line x1="16" x2="16" y1="2" y2="6" />
+              <line x1="8" x2="8" y1="2" y2="6" />
+              <line x1="3" x2="21" y1="10" y2="10" />
+            </svg>
+          </div>
+        )}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start justify-between gap-2">
+            <h3 className="font-bold text-[0.938rem] leading-snug tracking-[-0.01em] text-foreground">{event.title}</h3>
+            {event.type && (
+              <span className="flex items-center gap-1.5 shrink-0 mt-0.5">
+                <span className={`w-2 h-2 rounded-full ${TYPE_DOTS[event.type] || "bg-muted-foreground"}`} />
+                <span className="text-[0.6875rem] text-muted-foreground font-medium hidden min-[400px]:inline">{event.type}</span>
+              </span>
+            )}
+          </div>
+          {/* Date & time — prominent */}
+          <div className="flex items-center gap-1.5 mt-1.5">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5 shrink-0 text-primary/70">
+              <title>Date</title>
+              <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
+              <line x1="16" x2="16" y1="2" y2="6" />
+              <line x1="8" x2="8" y1="2" y2="6" />
+              <line x1="3" x2="21" y1="10" y2="10" />
+            </svg>
+            <span className="text-[0.8125rem] font-semibold text-foreground/80">{dateDisplay}</span>
+            <span aria-hidden="true" className="text-muted-foreground/40">·</span>
+            <span className="text-[0.8125rem] font-medium text-foreground/70">{event.time}</span>
+          </div>
         </div>
-        <Badge variant="secondary" className="text-xs shrink-0">
-          {event.category}
-        </Badge>
       </div>
 
-      <div className="flex items-center gap-2 text-xs text-muted-foreground flex-wrap w-full">
-        <span>{dateDisplay}</span>
-        <span>·</span>
-        <span>{event.time}</span>
-        <span>·</span>
-        <span className="truncate max-w-[150px]">{event.location}</span>
+      {/* Location */}
+      <div className="flex items-center gap-2 text-[0.8125rem] text-muted-foreground">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5 shrink-0 text-muted-foreground/70">
+          <title>Location</title>
+          <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
+          <circle cx="12" cy="10" r="3" />
+        </svg>
+        <span className="truncate">{event.location}</span>
+        {event.venueAddress && event.venueAddress !== event.location && (
+          <>
+            <span aria-hidden="true" className="text-muted-foreground/30">·</span>
+            <span className="truncate text-muted-foreground/70">{event.venueAddress}</span>
+          </>
+        )}
       </div>
 
-      <div className="flex items-center gap-2 w-full">
+      {/* Tags row */}
+      <div className="flex items-center gap-1.5 flex-wrap w-full">
         {event.type && (
-          <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${TYPE_COLORS[event.type] || "bg-muted text-muted-foreground"}`}>
+          <span className={`text-xs px-2.5 py-1 rounded-full font-medium ${TYPE_COLORS[event.type] || "bg-muted text-muted-foreground"}`}>
             {event.type}
           </span>
         )}
+        <Badge variant="secondary" className="text-xs px-2.5 py-1 rounded-full">
+          {event.category}
+        </Badge>
         {event.school && (
-          <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground font-medium">
+          <span className="text-xs px-2.5 py-1 rounded-full bg-muted text-muted-foreground font-medium">
             {event.school}
           </span>
         )}
       </div>
 
-      <p className="text-sm text-muted-foreground line-clamp-2 w-full">{event.description}</p>
+      {/* Description */}
+      {event.description && (
+        <p className="text-sm text-muted-foreground/90 leading-relaxed line-clamp-2 w-full">{event.description}</p>
+      )}
 
+      {/* Expandable long description */}
       {event.longDescription && (
-        <div className="w-full text-sm text-muted-foreground mt-1">
-          <div className={isExpanded ? "" : "line-clamp-2"}>
-            {event.longDescription}
+        <div className="w-full text-sm text-muted-foreground/90 leading-relaxed">
+          <div
+            ref={contentRef}
+            className="overflow-hidden transition-[max-height] duration-300 ease-in-out"
+            style={{
+              maxHeight: isExpanded
+                ? `${contentHeight || 500}px`
+                : "0px",
+            }}
+          >
+            <div className="pt-1">
+              {event.longDescription}
+            </div>
           </div>
           <button
             type="button"
@@ -105,51 +176,7 @@ export default function EventCard({ event }: EventCardProps) {
               e.stopPropagation();
               setIsExpanded(!isExpanded);
             }}
-            className="text-primary hover:underline mt-1 font-medium text-xs"
-          >
-            {isExpanded ? "Show less" : "Show more"}
-          </button>
-        </div>
-      )}
-
-      {event.venueAddress && (
-        <div className="flex items-start gap-1.5 text-sm text-muted-foreground mt-1 w-full">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="w-3.5 h-3.5 shrink-0 mt-0.5"
-          >
-            <title>Venue Address</title>
-            <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
-            <circle cx="12" cy="10" r="3" />
-          </svg>
-          <span className="leading-tight">{event.venueAddress}</span>
-        </div>
-      )}
-
-      <div className="flex items-center justify-end gap-2 w-full mt-1">
-        {event.registrationUrl && (
-          <a
-            href={event.registrationUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={(e) => e.stopPropagation()}
-            className="flex items-center gap-1.5 border border-primary text-primary px-3.5 py-2 rounded-lg text-sm font-medium hover:bg-primary/10 transition-colors"
-          >
-            <ExternalLink className="w-3.5 h-3.5" />
-            Register
-          </a>
-        )}
-        {event.type !== "Online" ? (
-          <button
-            type="button"
-            onClick={handleNavigate}
-            className="flex items-center gap-1.5 bg-primary text-primary-foreground px-3.5 py-2 rounded-lg text-sm font-medium hover:opacity-90 transition-opacity"
+            className="text-primary hover:text-primary/80 mt-1.5 font-medium text-xs min-h-[44px] flex items-center gap-1 transition-colors"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -159,13 +186,42 @@ export default function EventCard({ event }: EventCardProps) {
               strokeWidth="2"
               strokeLinecap="round"
               strokeLinejoin="round"
-              className="w-3.5 h-3.5"
+              className={`w-3.5 h-3.5 transition-transform duration-300 ${isExpanded ? "rotate-180" : ""}`}
             >
+              <title>{isExpanded ? "Collapse" : "Expand"}</title>
+              <path d="m6 9 6 6 6-6" />
+            </svg>
+            {isExpanded ? "Show less" : "Read more"}
+          </button>
+        </div>
+      )}
+
+      {/* Action buttons */}
+      <div className="flex items-center justify-end gap-2.5 w-full mt-0.5">
+        {event.registrationUrl && (
+          <a
+            href={event.registrationUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="flex items-center justify-center gap-2 border-2 border-primary/80 text-primary px-5 py-2.5 rounded-full text-sm font-semibold hover:bg-primary/10 active:bg-primary/20 transition-all min-h-[44px] min-w-[44px]"
+          >
+            <ExternalLink className="w-4 h-4" />
+            Register
+          </a>
+        )}
+        {event.type !== "Online" ? (
+          <button
+            type="button"
+            onClick={handleNavigate}
+            className="flex items-center justify-center gap-2 bg-primary text-primary-foreground px-5 py-2.5 rounded-full text-sm font-semibold hover:opacity-90 active:opacity-80 active:scale-95 transition-all min-h-[44px] min-w-[44px] shadow-sm"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
               <title>Navigate</title>
               <circle cx="12" cy="12" r="10" />
               <polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76" />
             </svg>
-            Navigate here
+            Navigate
           </button>
         ) : event.url ? (
           <a
@@ -173,9 +229,10 @@ export default function EventCard({ event }: EventCardProps) {
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => e.stopPropagation()}
-            className="text-xs text-primary hover:underline ml-auto"
+            className="flex items-center justify-center gap-2 bg-primary text-primary-foreground px-5 py-2.5 rounded-full text-sm font-semibold hover:opacity-90 active:opacity-80 active:scale-95 transition-all min-h-[44px] min-w-[44px] shadow-sm"
           >
-            Join Online →
+            <ExternalLink className="w-4 h-4" />
+            Join Online
           </a>
         ) : null}
       </div>

--- a/src/components/events/EventCardSkeleton.tsx
+++ b/src/components/events/EventCardSkeleton.tsx
@@ -1,17 +1,55 @@
-import { Skeleton } from "@/components/ui/skeleton";
+interface EventCardSkeletonProps {
+  index?: number;
+}
 
-export function EventCardSkeleton() {
+export function EventCardSkeleton({ index = 0 }: EventCardSkeletonProps) {
   return (
-    <div className="p-3 rounded-lg border space-y-2">
-      <div className="flex items-start justify-between gap-2">
-        <Skeleton className="h-4 w-3/4" />
-        <Skeleton className="h-4 w-12" />
+    <div
+      className="p-5 rounded-2xl border border-l-4 border-l-muted flex flex-col gap-3"
+      style={{
+        animationDelay: `${index * 100}ms`,
+      }}
+    >
+      {/* Header: logo + title + type dot */}
+      <div className="flex items-start gap-3.5">
+        <div className="w-10 h-10 rounded-xl skeleton-shimmer" />
+        <div className="flex-1 space-y-2.5">
+          <div className="flex items-start justify-between gap-2">
+            <div className="h-[1.125rem] w-3/4 rounded-md skeleton-shimmer" />
+            <div className="w-2 h-2 rounded-full skeleton-shimmer mt-1" />
+          </div>
+          {/* Date row */}
+          <div className="flex items-center gap-1.5">
+            <div className="w-3.5 h-3.5 rounded skeleton-shimmer" />
+            <div className="h-3.5 w-24 rounded skeleton-shimmer" />
+            <div className="h-3.5 w-14 rounded skeleton-shimmer" />
+          </div>
+        </div>
       </div>
-      <Skeleton className="h-3 w-full" />
-      <div className="flex gap-2">
-        <Skeleton className="h-3 w-16" />
-        <Skeleton className="h-3 w-12" />
-        <Skeleton className="h-3 w-20" />
+
+      {/* Location */}
+      <div className="flex items-center gap-2">
+        <div className="w-3.5 h-3.5 rounded skeleton-shimmer shrink-0" />
+        <div className="h-3.5 w-3/5 rounded skeleton-shimmer" />
+      </div>
+
+      {/* Tags */}
+      <div className="flex gap-1.5">
+        <div className="h-6 w-20 rounded-full skeleton-shimmer" />
+        <div className="h-6 w-28 rounded-full skeleton-shimmer" />
+        <div className="h-6 w-14 rounded-full skeleton-shimmer" />
+      </div>
+
+      {/* Description */}
+      <div className="space-y-2">
+        <div className="h-3.5 w-full rounded skeleton-shimmer" />
+        <div className="h-3.5 w-4/5 rounded skeleton-shimmer" />
+      </div>
+
+      {/* Buttons */}
+      <div className="flex justify-end gap-2.5 mt-0.5">
+        <div className="h-11 w-[6.5rem] rounded-full skeleton-shimmer" />
+        <div className="h-11 w-[6.5rem] rounded-full skeleton-shimmer" />
       </div>
     </div>
   );

--- a/src/components/events/EventFilter.tsx
+++ b/src/components/events/EventFilter.tsx
@@ -2,6 +2,7 @@
 
 import type { DateRangePreset } from "@/types";
 import { cn } from "@/lib/utils";
+import { X, SlidersHorizontal } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -13,7 +14,7 @@ import {
 const DATE_PRESETS: { value: DateRangePreset; label: string }[] = [
   { value: "1d", label: "Today" },
   { value: "3d", label: "3 Days" },
-  { value: "7d", label: "7 Days" },
+  { value: "7d", label: "This Week" },
   { value: "all", label: "All" },
 ];
 
@@ -36,48 +37,91 @@ export default function EventFilter({
   schoolFilter,
   onSchoolChange,
 }: EventFilterProps) {
+  const activeCount =
+    (dateFilter !== "all" ? 1 : 0) +
+    (categoryFilter !== "" ? 1 : 0) +
+    (schoolFilter !== "" ? 1 : 0);
+
   return (
-    <div className="flex gap-2 p-3 border-b flex-wrap">
-      <div className="flex w-full rounded-lg bg-muted p-[3px]">
+    <div className="flex flex-col gap-2.5 px-4 py-3 border-b border-border/60 bg-background/80 backdrop-blur-sm">
+      {/* Section header with filter count */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <SlidersHorizontal className="w-3.5 h-3.5 text-muted-foreground/70" />
+          <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Filters</span>
+          {activeCount > 0 && (
+            <span className="animate-hero-fade-in flex items-center justify-center w-5 h-5 rounded-full bg-primary text-primary-foreground text-[0.625rem] font-bold">
+              {activeCount}
+            </span>
+          )}
+        </div>
+        {activeCount > 0 && (
+          <button
+            type="button"
+            onClick={() => {
+              onDateChange("all");
+              onCategoryChange("");
+              onSchoolChange("");
+            }}
+            className="animate-hero-fade-in flex items-center gap-1 text-xs text-primary hover:text-primary/80 font-medium transition-colors min-h-[44px] px-2"
+          >
+            <X className="w-3 h-3" />
+            Clear all
+          </button>
+        )}
+      </div>
+
+      {/* Date segmented control */}
+      <div className="flex w-full rounded-xl bg-muted/70 p-1">
         {DATE_PRESETS.map((p) => (
           <button
             key={p.value}
             type="button"
             onClick={() => onDateChange(p.value)}
             className={cn(
-              "flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+              "flex-1 rounded-lg px-3 py-2.5 text-sm font-medium transition-all duration-200 min-h-[44px]",
               dateFilter === p.value
-                ? "bg-background text-foreground shadow-sm"
-                : "text-foreground/60 hover:text-foreground"
+                ? "bg-background text-foreground shadow-sm ring-1 ring-border/50"
+                : "text-muted-foreground hover:text-foreground active:bg-background/50"
             )}
           >
             {p.label}
           </button>
         ))}
       </div>
-      <Select value={categoryFilter} onValueChange={(value) => onCategoryChange(value ?? "")}>
-        <SelectTrigger className="text-sm h-9 rounded-md bg-background px-3 w-[160px]">
-          <SelectValue placeholder="All categories" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="">All categories</SelectItem>
-          {categories.map((cat) => (
-            <SelectItem key={cat} value={cat}>
-              {cat}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-      <Select value={schoolFilter} onValueChange={(value) => onSchoolChange(value ?? "")}>
-        <SelectTrigger className="text-sm h-9 rounded-md bg-background px-3 w-[120px]">
-          <SelectValue placeholder="All schools" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="">All schools</SelectItem>
-          <SelectItem value="SUSS">SUSS</SelectItem>
-          <SelectItem value="SIM">SIM</SelectItem>
-        </SelectContent>
-      </Select>
+
+      {/* Category & School — full-width stacked on narrow screens */}
+      <div className="flex flex-col min-[400px]:flex-row gap-2 w-full">
+        <Select value={categoryFilter} onValueChange={(value) => onCategoryChange(value ?? "")}>
+          <SelectTrigger className={cn(
+            "text-sm h-12 rounded-xl bg-background px-3.5 flex-1 min-w-0 transition-all duration-200",
+            categoryFilter && "ring-2 ring-primary/30 border-primary/40"
+          )}>
+            <SelectValue placeholder="All categories" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="">All categories</SelectItem>
+            {categories.map((cat) => (
+              <SelectItem key={cat} value={cat}>
+                {cat}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={schoolFilter} onValueChange={(value) => onSchoolChange(value ?? "")}>
+          <SelectTrigger className={cn(
+            "text-sm h-12 rounded-xl bg-background px-3.5 min-[400px]:w-[130px] shrink-0 transition-all duration-200",
+            schoolFilter && "ring-2 ring-primary/30 border-primary/40"
+          )}>
+            <SelectValue placeholder="All schools" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="">All schools</SelectItem>
+            <SelectItem value="SUSS">SUSS</SelectItem>
+            <SelectItem value="SIM">SIM</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
     </div>
   );
 }

--- a/src/components/events/EventsPanel.tsx
+++ b/src/components/events/EventsPanel.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { EmptyState } from "@/components/ui/empty-state";
-import { CalendarX } from "lucide-react";
+import { CalendarX, ChevronUp } from "lucide-react";
 import { useCampusEvents } from "@/hooks/useCampusEvents";
 import { useAppStore } from "@/store/app-store";
 import type { DateRangePreset } from "@/types";
@@ -28,6 +28,9 @@ export default function EventsPanel() {
   const storeCategory = useAppStore((s) => s.eventCategoryFilter);
   const setMapEventMarkers = useAppStore((s) => s.setMapEventMarkers);
 
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [showScrollTop, setShowScrollTop] = useState(false);
+
   useEffect(() => {
     if (storeDate) setDateFilter(storeDate);
   }, [storeDate, setDateFilter]);
@@ -40,8 +43,30 @@ export default function EventsPanel() {
     setMapEventMarkers(events);
   }, [events, setMapEventMarkers]);
 
+  // Track scroll to show/hide scroll-to-top button
+  useEffect(() => {
+    const viewport = scrollRef.current?.querySelector("[data-radix-scroll-area-viewport]");
+    if (!viewport) return;
+    const handleScroll = () => {
+      setShowScrollTop(viewport.scrollTop > 400);
+    };
+    viewport.addEventListener("scroll", handleScroll, { passive: true });
+    return () => viewport.removeEventListener("scroll", handleScroll);
+  }, [isLoading]);
+
+  const scrollToTop = useCallback(() => {
+    const viewport = scrollRef.current?.querySelector("[data-radix-scroll-area-viewport]");
+    viewport?.scrollTo({ top: 0, behavior: "smooth" });
+  }, []);
+
+  const handleClearFilters = useCallback(() => {
+    setDateFilter("all");
+    setCategoryFilter("");
+    setSchoolFilter("");
+  }, [setDateFilter, setCategoryFilter, setSchoolFilter]);
+
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full relative">
       <EventFilter
         dateFilter={dateFilter}
         onDateChange={(preset: DateRangePreset) => setDateFilter(preset)}
@@ -51,41 +76,60 @@ export default function EventsPanel() {
         schoolFilter={schoolFilter}
         onSchoolChange={setSchoolFilter}
       />
-      <ScrollArea className="flex-1 p-3">
+      <ScrollArea ref={scrollRef} className="flex-1 px-4 py-3">
         {isLoading ? (
-          <div className="space-y-2">
-            <EventCardSkeleton />
-            <EventCardSkeleton />
-            <EventCardSkeleton />
+          <div className="space-y-3">
+            {[0, 1, 2, 3].map((i) => (
+              <EventCardSkeleton key={i} index={i} />
+            ))}
           </div>
         ) : events.length === 0 ? (
           <EmptyState
-            icon={<CalendarX className="h-8 w-8 text-muted-foreground" />}
+            icon={
+              <div className="flex flex-col items-center gap-3 mb-1">
+                <div className="w-16 h-16 rounded-2xl bg-muted/60 flex items-center justify-center">
+                  <CalendarX className="h-8 w-8 text-muted-foreground/50" />
+                </div>
+              </div>
+            }
             title="No events found"
-            description="Try adjusting your filters."
+            description="Try adjusting your filters or check back later — new events are added regularly."
             action={
               <button
                 type="button"
-                onClick={() => {
-                  setDateFilter("all");
-                  setCategoryFilter("");
-                  setSchoolFilter("");
-                }}
-                className="mt-1 text-sm text-primary hover:underline font-medium"
+                onClick={handleClearFilters}
+                className="mt-3 text-sm text-primary hover:text-primary/80 font-semibold min-h-[44px] flex items-center gap-1.5 transition-colors px-4 py-2 rounded-full border border-primary/20 hover:bg-primary/5"
               >
                 Clear all filters
               </button>
             }
           />
         ) : (
-          <div className="space-y-2">
-            <p className="text-sm text-muted-foreground px-1 font-medium">{events.length} events</p>
-            {events.map((event) => (
-              <EventCard key={event.id} event={event} />
+          <div className="space-y-3">
+            <div className="flex items-center justify-between px-1">
+              <p className="text-xs text-muted-foreground font-semibold tracking-wide uppercase">
+                <span className="tabular-nums">{events.length}</span>
+                {" "}event{events.length !== 1 ? "s" : ""}
+              </p>
+            </div>
+            {events.map((event, i) => (
+              <EventCard key={event.id} event={event} index={i} />
             ))}
           </div>
         )}
       </ScrollArea>
+
+      {/* Scroll to top FAB */}
+      {showScrollTop && (
+        <button
+          type="button"
+          onClick={scrollToTop}
+          aria-label="Scroll to top"
+          className="absolute bottom-4 right-4 z-10 w-11 h-11 rounded-full bg-primary text-primary-foreground shadow-lg shadow-primary/20 flex items-center justify-center hover:opacity-90 active:scale-90 transition-all animate-hero-fade-in-up min-w-[44px] min-h-[44px]"
+        >
+          <ChevronUp className="w-5 h-5" />
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/layout/Onboarding.tsx
+++ b/src/components/layout/Onboarding.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import { X, MapPin, Calendar, Utensils, BookOpen, Bus, MessageCircle } from "lucide-react";
 import { useAppStore } from "@/store/app-store";
@@ -26,6 +26,9 @@ export default function Onboarding() {
   const setOnboardingDismissed = useAppStore((s) => s.setOnboardingDismissed);
   const setPendingChatMessage = useAppStore((s) => s.setPendingChatMessage);
   const dialogRef = useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragY, setDragY] = useState(0);
+  const dragStart = useRef(0);
 
   const handleDismiss = useCallback(() => {
     setOnboardingDismissed(true);
@@ -38,6 +41,25 @@ export default function Onboarding() {
     },
     [setOnboardingDismissed, setPendingChatMessage]
   );
+
+  // Swipe-down to dismiss
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    dragStart.current = e.touches[0].clientY;
+    setIsDragging(true);
+  }, []);
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    const delta = e.touches[0].clientY - dragStart.current;
+    if (delta > 0) setDragY(delta);
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
+    setIsDragging(false);
+    if (dragY > 120) {
+      handleDismiss();
+    }
+    setDragY(0);
+  }, [dragY, handleDismiss]);
 
   useEffect(() => {
     if (onboardingDismissed) return;
@@ -63,26 +85,49 @@ export default function Onboarding() {
   if (onboardingDismissed) return null;
 
   return (
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <div
-      className="fixed inset-0 z-[45] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      className="fixed inset-0 z-[45] flex items-end sm:items-center justify-center bg-black/50 backdrop-blur-sm p-0 sm:p-4"
       role="dialog"
       aria-modal="true"
       aria-label="Welcome to AskSUSSi"
+      onKeyDown={(e) => {
+        if (e.key === "Escape") handleDismiss();
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) handleDismiss();
+      }}
     >
       <div
         ref={dialogRef}
-        className="relative w-full max-w-md bg-background rounded-2xl shadow-2xl border border-border overflow-hidden animate-hero-fade-in-up"
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        style={{
+          transform: dragY > 0 ? `translateY(${dragY}px)` : undefined,
+          transition: isDragging ? "none" : "transform 0.3s ease-out",
+          opacity: dragY > 80 ? 1 - (dragY - 80) / 120 : 1,
+        }}
+        className="relative w-full sm:max-w-md max-h-[92dvh] bg-background rounded-t-3xl sm:rounded-2xl shadow-2xl border border-border overflow-y-auto animate-hero-fade-in-up"
       >
-        <div className="bg-surface-brand px-6 py-5 text-surface-brand-foreground">
+        {/* Swipe handle — mobile only */}
+        <div className="flex justify-center pt-3 pb-1 sm:hidden sticky top-0 z-20 bg-background">
+          <div className="w-10 h-1 rounded-full bg-muted-foreground/20" />
+        </div>
+
+        {/* Header with gradient */}
+        <div className="bg-gradient-to-br from-surface-brand to-surface-brand-hover px-6 py-5 text-surface-brand-foreground relative overflow-hidden sticky top-0 sm:top-0 z-10">
+          {/* Subtle radial glow */}
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_80%_20%,rgba(255,255,255,0.08)_0%,transparent_50%)] pointer-events-none" />
           <button
             type="button"
             onClick={handleDismiss}
             aria-label="Close welcome dialog"
-            className="absolute top-4 right-4 flex items-center justify-center w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 transition-colors text-white/80 hover:text-white"
+            className="absolute top-4 right-4 flex items-center justify-center w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 active:bg-white/30 backdrop-blur-sm transition-colors text-white/80 hover:text-white min-w-[44px] min-h-[44px]"
           >
-            <X size={16} />
+            <X size={18} />
           </button>
-          <div className="flex items-center gap-3 mb-3">
+          <div className="flex items-center gap-3 mb-3 relative">
             <Image
               src="/suss-logo.png"
               alt="SUSS"
@@ -94,43 +139,49 @@ export default function Onboarding() {
             <div className="h-5 w-px bg-white/25" />
             <span className="text-sm font-bold tracking-wide opacity-90">AskSUSSi</span>
           </div>
-          <h2 className="text-lg font-bold">Welcome to your campus assistant</h2>
-          <p className="text-sm opacity-80 mt-1">
+          <h2 className="text-xl font-bold relative">Welcome to your campus assistant</h2>
+          <p className="text-sm opacity-80 mt-1.5 leading-relaxed relative">
             I can help you navigate, find events, and discover what&apos;s around SUSS.
           </p>
         </div>
 
-        <div className="px-6 py-4">
+        {/* Capabilities — single-column scrollable list on mobile, 2-col on wider */}
+        <div className="px-5 py-4">
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">
             What I can do
           </p>
-          <div className="grid grid-cols-2 gap-2">
-            {CAPABILITIES.map(({ icon: Icon, label, description }) => (
+          <div className="flex flex-col gap-2 sm:grid sm:grid-cols-2">
+            {CAPABILITIES.map(({ icon: Icon, label, description }, i) => (
               <div
                 key={label}
-                className="flex items-start gap-2.5 rounded-lg border border-border/60 bg-muted/40 p-2.5"
+                className="flex items-center gap-3 rounded-xl border border-border/50 bg-muted/30 p-3 animate-hero-fade-in-up"
+                style={{ animationDelay: `${200 + i * 60}ms` }}
               >
-                <Icon size={16} className="text-primary mt-0.5 shrink-0" aria-hidden="true" />
-                <div>
-                  <p className="text-sm font-medium text-foreground">{label}</p>
-                  <p className="text-xs text-muted-foreground">{description}</p>
+                <div className="w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+                  <Icon size={18} className="text-primary" aria-hidden="true" />
+                </div>
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-foreground">{label}</p>
+                  <p className="text-xs text-muted-foreground leading-snug">{description}</p>
                 </div>
               </div>
             ))}
           </div>
         </div>
 
-        <div className="px-6 pb-5">
-          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+        {/* Try suggestions — larger touch targets with staggered entrance */}
+        <div className="px-5 pb-4">
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2.5">
             Try asking...
           </p>
           <div className="flex flex-wrap gap-2">
-            {TRY_SUGGESTIONS.map((text) => (
+            {TRY_SUGGESTIONS.map((text, i) => (
               <button
                 key={text}
                 type="button"
                 onClick={() => handleTrySuggestion(text)}
-                className="text-sm px-3 py-1.5 rounded-full border border-primary/20 text-primary hover:bg-primary hover:text-primary-foreground transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="text-sm px-4 py-2.5 rounded-full border border-primary/20 text-primary hover:bg-primary hover:text-primary-foreground active:bg-primary/90 transition-all duration-200 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring min-h-[44px] animate-hero-fade-in"
+                style={{ animationDelay: `${600 + i * 80}ms` }}
               >
                 {text}
               </button>
@@ -138,11 +189,12 @@ export default function Onboarding() {
           </div>
         </div>
 
-        <div className="px-6 pb-5">
+        {/* CTA */}
+        <div className="px-5 pb-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] pt-1">
           <button
             type="button"
             onClick={handleDismiss}
-            className="w-full bg-primary text-primary-foreground rounded-lg px-4 py-2.5 text-sm font-semibold hover:bg-primary/90 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="w-full bg-primary text-primary-foreground rounded-xl px-4 py-3.5 text-[0.938rem] font-bold hover:bg-primary/90 active:bg-primary/80 active:scale-[0.98] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring min-h-[48px] shadow-sm"
           >
             Get Started
           </button>


### PR DESCRIPTION
## Events & Discovery UX Polish (clean rebase)

Supersedes #25 (had merge conflicts from other merged branches).

### Changes
- **EventCard**: Better visual hierarchy, 44px+ touch targets, staggered entrance animations, bolder date/time
- **EventFilter**: Full-width stacked filters for mobile, animated active states, filter count badge, clear-all chip
- **EventsPanel**: Dynamic event count, improved empty state, scroll hints
- **EventCardSkeleton**: Shimmer animation matching actual card layout
- **Onboarding**: Mobile-optimized capability grid, larger suggestion chips, swipe-to-dismiss
- **globals.css**: shimmer-slide and stagger-in keyframes

6 files changed, +408 / -162 lines. UI/UX only, no business logic changes.