### PR TITLE
fix(aac): fly map to user location on geolocation success

### DIFF
--- a/src/components/aac/AACSearchPanel.tsx
+++ b/src/components/aac/AACSearchPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { Search, MapPin, Navigation, Loader2 } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -28,6 +28,12 @@ export default function AACSearchPanel() {
   const { lat, lng, status, error, requestLocation } = useGeolocation();
 
   const hasLocation = status === "success" && lat !== null && lng !== null;
+
+  useEffect(() => {
+    if (status === "success" && lat !== null && lng !== null) {
+      setFlyToTarget({ lat, lng, altitude: 3000 });
+    }
+  }, [status, lat, lng, setFlyToTarget]);
 
   const results: AACWithDistance[] = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();

--- a/tests/components/aac/AACSearchPanel.test.tsx
+++ b/tests/components/aac/AACSearchPanel.test.tsx
@@ -138,6 +138,30 @@ describe("AACSearchPanel", () => {
       btn.textContent?.includes("AAC"),
     );
     expect(cards[0]).toHaveTextContent("Beta AAC");
+    expect(mockSetFlyToTarget).toHaveBeenCalledWith({
+      lat: 1.314,
+      lng: 103.764,
+      altitude: 3000,
+    });
+  });
+
+  it("flies map to user location on geolocation success", () => {
+    setGeoState({ lat: 1.29, lng: 103.85, status: "success" });
+    render(<AACSearchPanel />);
+
+    expect(mockSetFlyToTarget).toHaveBeenCalledOnce();
+    expect(mockSetFlyToTarget).toHaveBeenCalledWith({
+      lat: 1.29,
+      lng: 103.85,
+      altitude: 3000,
+    });
+  });
+
+  it("does not fly map when geolocation is idle", () => {
+    setGeoState({ status: "idle" });
+    render(<AACSearchPanel />);
+
+    expect(mockSetFlyToTarget).not.toHaveBeenCalled();
   });
 
   it("calls requestLocation when button is clicked", () => {


### PR DESCRIPTION
## Summary

- **Bug**: Clicking "Use My Location" in the AAC search tab only sorted results by distance but did not move the 3D map camera to the user's location
- **Fix**: Added a `useEffect` in `AACSearchPanel` that calls `setFlyToTarget({ lat, lng, altitude: 3000 })` when geolocation succeeds, giving a wide aerial view of surrounding Active Ageing Centres
- **Tests**: Added 2 new test cases (fly-to on success, no fly-to on idle) — 51 tests total, all passing

## Changes

| File | Change |
|---|---|
| `src/components/aac/AACSearchPanel.tsx` | Added `useEffect` to trigger map fly-to on geolocation success (altitude 3000m) |
| `tests/components/aac/AACSearchPanel.test.tsx` | Added 2 tests for fly-to behavior; updated existing distance-sort test to assert fly-to call |

## Verification

- ✅ 51 tests passing (6 test files)
- ✅ 0 lint errors
- ✅ `next build` clean
- ✅ 0 TypeScript errors