### PR TITLE
fix(geo): enable high-accuracy geolocation and scale camera range

### DIFF
--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -228,14 +228,15 @@ function Map3DInner() {
 
   useEffect(() => {
     if (!flyToTarget || !mapRef.current) return;
+    const altitude = flyToTarget.altitude || 200;
     mapRef.current.flyCameraTo({
       endCamera: {
         center: {
           lat: flyToTarget.lat,
           lng: flyToTarget.lng,
-          altitude: flyToTarget.altitude || 200,
+          altitude,
         },
-        range: 400,
+        range: altitude * 2,
         tilt: 60,
         heading: 0,
       },

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -47,7 +47,7 @@ export function useGeolocation(): GeolocationState {
           setError("Unable to retrieve your location. Please try again.");
         }
       },
-      { enableHighAccuracy: false, timeout: 10000, maximumAge: 300000 },
+      { enableHighAccuracy: true, timeout: 15000, maximumAge: 60000 },
     );
   }, []);
 

--- a/tests/hooks/useGeolocation.test.ts
+++ b/tests/hooks/useGeolocation.test.ts
@@ -49,6 +49,11 @@ describe("useGeolocation", () => {
     act(() => result.current.requestLocation());
 
     expect(geo.getCurrentPosition).toHaveBeenCalledOnce();
+    expect(geo.getCurrentPosition).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({ enableHighAccuracy: true }),
+    );
     expect(result.current.status).toBe("success");
     expect(result.current.lat).toBe(1.314);
     expect(result.current.lng).toBe(103.765);


### PR DESCRIPTION
## Summary

- **Bug**: "Use My Location" flew the map to the wrong location because `enableHighAccuracy: false` caused the browser to use coarse IP/cell-tower positioning (off by hundreds of meters to kilometers)
- **Fix**: Switched to `enableHighAccuracy: true` (GPS/WiFi triangulation), reduced `maximumAge` from 5 min to 60s, increased `timeout` to 15s for GPS lock time
- **Camera**: Scaled `flyCameraTo` range proportionally to altitude (`range = altitude × 2`) so bird's-eye views at higher altitudes are properly framed

## Changes

| File | Change |
|---|---|
| `src/hooks/useGeolocation.ts` | `enableHighAccuracy: true`, `timeout: 15000`, `maximumAge: 60000` |
| `src/components/map/MapView.tsx` | Scale `range` proportionally to `altitude` instead of hardcoded 400m |
| `tests/hooks/useGeolocation.test.ts` | Assert `enableHighAccuracy: true` is passed to `getCurrentPosition` |

## Verification

- ✅ 51 tests passing (6 test files)
- ✅ 0 lint errors
- ✅ `next build` clean
- ✅ 0 TypeScript errors