### PR TITLE
fix(events): replace broken organizerLogo images with category-based Lucide icons

### DIFF
--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useRef, useState, useCallback, useEffect } from "react";
+import { useRef, useState, useEffect } from "react";
 import type { CampusEvent } from "@/types";
 import { Badge } from "@/components/ui/badge";
 import { ExternalLink } from "lucide-react";
 import { useAppStore } from "@/store/app-store";
+import { CATEGORY_ICON, DEFAULT_EVENT_ICON, CATEGORY_ICON_BG, DEFAULT_ICON_BG } from "@/lib/event-icons";
 
 interface EventCardProps {
   event: CampusEvent;
@@ -61,6 +62,9 @@ export default function EventCard({ event, index = 0 }: EventCardProps) {
     ? `${event.date} – ${event.endDate}`
     : event.date;
 
+  const CategoryIcon = CATEGORY_ICON[event.category] ?? DEFAULT_EVENT_ICON;
+  const iconBg = CATEGORY_ICON_BG[event.category] ?? DEFAULT_ICON_BG;
+
   return (
     <button
       type="button"
@@ -69,27 +73,11 @@ export default function EventCard({ event, index = 0 }: EventCardProps) {
       style={{ "--card-index": index } as React.CSSProperties}
       className={`animate-card-slide-in w-full text-left rounded-2xl border border-border/60 border-l-4 ${CATEGORY_ACCENT[event.category] || "border-l-gray-300"} bg-card hover:bg-muted/30 active:bg-muted/50 active:scale-[0.985] transition-all duration-200 ease-out flex flex-col gap-3 shadow-[0_1px_3px_rgba(0,0,0,0.06)] hover:shadow-[0_4px_12px_rgba(0,0,0,0.08)] p-5`}
     >
-      {/* Header: logo + title + type indicator */}
+      {/* Header: icon + title + type indicator */}
       <div className="flex items-start gap-3.5 w-full">
-        {event.organizerLogo ? (
-          <img
-            src={event.organizerLogo}
-            alt={`${event.title} organizer`}
-            width={40}
-            height={40}
-            className="w-10 h-10 rounded-xl shrink-0 object-cover border border-border/40 shadow-sm"
-          />
-        ) : (
-          <div className="w-10 h-10 rounded-xl shrink-0 bg-muted flex items-center justify-center border border-border/40">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5 text-muted-foreground/60">
-              <title>Event</title>
-              <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
-              <line x1="16" x2="16" y1="2" y2="6" />
-              <line x1="8" x2="8" y1="2" y2="6" />
-              <line x1="3" x2="21" y1="10" y2="10" />
-            </svg>
-          </div>
-        )}
+        <div className={`w-10 h-10 rounded-xl shrink-0 flex items-center justify-center border border-border/40 ${iconBg}`}>
+          <CategoryIcon className="w-5 h-5" aria-hidden="true" />
+        </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-start justify-between gap-2">
             <h3 className="font-bold text-[0.938rem] leading-snug tracking-[-0.01em] text-foreground">{event.title}</h3>

--- a/src/components/ui/EventRow.tsx
+++ b/src/components/ui/EventRow.tsx
@@ -4,6 +4,7 @@ import { MapPin, ExternalLink } from "lucide-react";
 import type { CampusEvent } from "@/types";
 import { isOffSiteEvent } from "@/lib/maps/aac-events";
 import { formatEventDate, formatEventDateRange } from "@/lib/date-utils";
+import { CATEGORY_ICON, DEFAULT_EVENT_ICON, CATEGORY_ICON_BG, DEFAULT_ICON_BG } from "@/lib/event-icons";
 
 interface EventRowProps {
   event: CampusEvent;
@@ -29,6 +30,8 @@ export default function EventRow({
     ? formatEventDate(event.date)
     : formatEventDateRange(event.date, event.endDate);
 
+  const CategoryIcon = CATEGORY_ICON[event.category] ?? DEFAULT_EVENT_ICON;
+
   return (
     <div className="flex items-start gap-2.5 min-h-[44px]">
       <button
@@ -36,14 +39,10 @@ export default function EventRow({
         onClick={() => onEventClick(event)}
         className="flex-1 min-w-0 text-left flex items-start gap-2.5 bg-secondary/50 border border-secondary rounded-lg px-3.5 py-2.5 hover:bg-secondary/80 active:bg-secondary transition-colors"
       >
-        {!compact && event.organizerLogo && (
-          <img
-            src={event.organizerLogo}
-            alt=""
-            width={24}
-            height={24}
-            className="w-6 h-6 rounded-md shrink-0 object-cover border border-border/40 mt-0.5"
-          />
+        {!compact && (
+          <div className={`w-6 h-6 rounded-md shrink-0 flex items-center justify-center mt-0.5 ${CATEGORY_ICON_BG[event.category] ?? DEFAULT_ICON_BG}`}>
+            <CategoryIcon className="w-3.5 h-3.5" aria-hidden="true" />
+          </div>
         )}
         <span className="text-primary text-xs font-medium shrink-0 mt-0.5 min-w-[52px]">
           {dateLabel}

--- a/src/lib/event-icons.ts
+++ b/src/lib/event-icons.ts
@@ -1,0 +1,51 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  Info,
+  DoorOpen,
+  Presentation,
+  Users,
+  Briefcase,
+  BookOpen,
+  MessageSquare,
+  Landmark,
+  PartyPopper,
+  Trophy,
+  Calendar,
+} from "lucide-react";
+
+export const CATEGORY_ICON: Record<string, LucideIcon> = {
+  "Information Session": Info,
+  "Open House": DoorOpen,
+  "Public Lecture / Enrichment Talk": Presentation,
+  Symposium: Users,
+  "Competition / Hackathon": Trophy,
+  Career: Briefcase,
+  "Career Fair": Briefcase,
+  Lecture: BookOpen,
+  "Forum / Conference": MessageSquare,
+  Forum: MessageSquare,
+  Conference: Landmark,
+  Social: PartyPopper,
+};
+
+export const DEFAULT_EVENT_ICON: LucideIcon = Calendar;
+
+export const CATEGORY_ICON_BG: Record<string, string> = {
+  "Information Session": "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+  "Open House": "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+  "Public Lecture / Enrichment Talk":
+    "bg-violet-500/10 text-violet-600 dark:text-violet-400",
+  Symposium: "bg-teal-500/10 text-teal-600 dark:text-teal-400",
+  "Competition / Hackathon":
+    "bg-orange-500/10 text-orange-600 dark:text-orange-400",
+  Career: "bg-sky-500/10 text-sky-600 dark:text-sky-400",
+  "Career Fair": "bg-sky-500/10 text-sky-600 dark:text-sky-400",
+  Lecture: "bg-violet-500/10 text-violet-600 dark:text-violet-400",
+  "Forum / Conference":
+    "bg-teal-500/10 text-teal-600 dark:text-teal-400",
+  Forum: "bg-teal-500/10 text-teal-600 dark:text-teal-400",
+  Conference: "bg-teal-500/10 text-teal-600 dark:text-teal-400",
+  Social: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+};
+
+export const DEFAULT_ICON_BG = "bg-muted text-muted-foreground/60";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,7 +38,6 @@ export interface CampusEvent {
   url?: string;
   venueAddress?: string;
   longDescription?: string;
-  organizerLogo?: string;
   registrationUrl?: string;
 }
 


### PR DESCRIPTION
## Summary

- Removed dead `organizerLogo` field from `CampusEvent` type — it was never populated in any event data
- Replaced the `<img>` + fallback SVG blocks in `EventCard` and `EventRow` with category-specific Lucide icons (e.g. `Info` for Information Sessions, `Presentation` for lectures, `Briefcase` for career events)
- Added color-coded icon backgrounds that complement the existing category accent border colors
- Created shared `src/lib/event-icons.ts` utility with `CATEGORY_ICON` and `CATEGORY_ICON_BG` mappings
- Removed unused `useCallback` import from `EventCard`

## Verification

- 51 tests passing
- 0 lint errors (3 pre-existing warnings unchanged)
- `next build` succeeds with zero errors