### PR TITLE
fix(ci): add test step to CI workflow (#43)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
 
       - run: npm run lint
 
+      - run: npm test
+
       - name: No hard-coded colors
         run: |
           if grep -rn --include='*.tsx' --include='*.ts' 'bg-\[#\|text-\[#\|border-\[#' src/; then


### PR DESCRIPTION
Closes #43

## Changes
- Add `npm test` step to CI pipeline after lint and before build
- 13 existing test files will now run on every push/PR