### PR TITLE
fix(a11y): add aria-label to AACResultCard (#49)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2433,9 +2433,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2453,9 +2450,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2473,9 +2467,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2493,9 +2484,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2513,9 +2501,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2533,9 +2518,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12854,9 +12836,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12878,9 +12857,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12902,9 +12878,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12926,9 +12899,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/components/aac/AACResultCard.tsx
+++ b/src/components/aac/AACResultCard.tsx
@@ -18,6 +18,7 @@ export default function AACResultCard({ poi, distanceKm, onSelect }: AACResultCa
   return (
     <button
       type="button"
+      aria-label={`Select ${poi.name}`}
       onClick={() => onSelect(poi)}
       className="w-full text-left px-3 py-2.5 rounded-lg border border-border bg-card hover:bg-accent/50 active:bg-accent transition-colors cursor-pointer group"
     >


### PR DESCRIPTION
Closes #49

## Changes
- Add `aria-label` to AACResultCard button for screen reader support