### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs (#53)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     name: Build & Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
         with:
           node-version: 24
           cache: npm
@@ -43,7 +43,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install Railway CLI
         run: npm install -g @railway/cli


### PR DESCRIPTION
Closes #53

## Changes
- Pin `actions/checkout` to v4.2.2 SHA (`11bd71901bbe5b1630ceea73d27597364c9af683`)
- Pin `actions/setup-node` to v4.1.0 SHA (`39370e3970a6d050c480ffad4ff0ed4d3fdee5af`)
- Add version comments for readability