### PR TITLE
fix(a11y): add ARIA attributes to EventFilter (#48)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2433,9 +2433,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2453,9 +2450,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2473,9 +2467,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2493,9 +2484,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2513,9 +2501,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2533,9 +2518,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12854,9 +12836,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12878,9 +12857,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12902,9 +12878,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12926,9 +12899,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/components/events/EventFilter.tsx
+++ b/src/components/events/EventFilter.tsx
@@ -43,14 +43,14 @@ export default function EventFilter({
     (schoolFilter !== "" ? 1 : 0);
 
   return (
-    <div className="flex flex-col gap-2.5 px-4 py-3 border-b border-border/60 bg-background/80 backdrop-blur-sm">
+    <div role="search" aria-label="Event filters" className="flex flex-col gap-2.5 px-4 py-3 border-b border-border/60 bg-background/80 backdrop-blur-sm">
       {/* Section header with filter count */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <SlidersHorizontal className="w-3.5 h-3.5 text-muted-foreground/70" />
           <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Filters</span>
           {activeCount > 0 && (
-            <span className="animate-hero-fade-in flex items-center justify-center w-5 h-5 rounded-full bg-primary text-primary-foreground text-[0.625rem] font-bold">
+             <span aria-live="polite" className="animate-hero-fade-in flex items-center justify-center w-5 h-5 rounded-full bg-primary text-primary-foreground text-[0.625rem] font-bold">
               {activeCount}
             </span>
           )}
@@ -58,6 +58,7 @@ export default function EventFilter({
         {activeCount > 0 && (
           <button
             type="button"
+            aria-label="Clear all filters"
             onClick={() => {
               onDateChange("all");
               onCategoryChange("");
@@ -72,11 +73,12 @@ export default function EventFilter({
       </div>
 
       {/* Date segmented control */}
-      <div className="flex w-full rounded-xl bg-muted/70 p-1">
+      <div role="group" aria-label="Date range" className="flex w-full rounded-xl bg-muted/70 p-1">
         {DATE_PRESETS.map((p) => (
           <button
             key={p.value}
             type="button"
+            aria-pressed={dateFilter === p.value}
             onClick={() => onDateChange(p.value)}
             className={cn(
               "flex-1 rounded-lg px-3 py-2.5 text-sm font-medium transition-all duration-200 min-h-[44px]",


### PR DESCRIPTION
Closes #48

## Changes
- Add `role="search"` and `aria-label="Event filters"` to filter container
- Add `role="group"` and `aria-label="Date range"` to date range button group
- Add `aria-pressed` state to date preset buttons
- Add `aria-label="Clear all filters"` to Clear all button
- Add `aria-live="polite"` to active filter count badge

## Verification
- `npm run build` passes with zero errors
- No styling, layout, or functionality changes
- Radix UI Select components left untouched (built-in ARIA)