### PR TITLE
fix(typing): replace (window as any) with proper Google Maps types (#50)

### DIFF
--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -45,8 +45,7 @@ function loadMapsAPI(): Promise<void> {
   if (mapsReady) return mapsReady;
 
   mapsReady = (async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (!(window as any).google?.maps) {
+    if (!window.google?.maps) {
       const existing = document.querySelector(
         'script[src*="maps.googleapis.com/maps/api/js"]'
       );
@@ -58,8 +57,7 @@ function loadMapsAPI(): Promise<void> {
       }
 
       const deadline = Date.now() + 15000;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      while (!(window as any).google?.maps?.importLibrary) {
+      while (!window.google?.maps?.importLibrary) {
         if (Date.now() > deadline) {
           throw new Error(
             "Google Maps API failed to initialize — ensure Maps JavaScript API and Map Tiles API are enabled in your GCP project."
@@ -69,8 +67,7 @@ function loadMapsAPI(): Promise<void> {
       }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (window as any).google.maps.importLibrary("maps3d");
+    await window.google.maps.importLibrary("maps3d");
   })();
 
   mapsReady.catch(() => {

--- a/src/types/google-maps.d.ts
+++ b/src/types/google-maps.d.ts
@@ -1,0 +1,20 @@
+export {};
+
+declare global {
+  interface GoogleMapsAPI {
+    importLibrary: (library: string) => Promise<unknown>;
+    StreetViewPanorama: new (
+      container: HTMLElement,
+      opts: Record<string, unknown>
+    ) => { setVisible: (v: boolean) => void };
+    event: {
+      clearInstanceListeners: (instance: unknown) => void;
+    };
+  }
+
+  interface Window {
+    google?: {
+      maps?: GoogleMapsAPI;
+    };
+  }
+}


### PR DESCRIPTION
Closes #50

## Summary
- Add `src/types/google-maps.d.ts` with `Window.google.maps` type declaration (`GoogleMapsAPI` interface)
- Remove 3 `(window as any)` casts in `MapView.tsx` (lines 49, 62, 73)
- Remove 3 `eslint-disable-next-line @typescript-eslint/no-explicit-any` comments (lines 48, 61, 72)

## Changes
- **New file**: `src/types/google-maps.d.ts` — declares `GoogleMapsAPI` interface and augments `Window` with `google?.maps?` property
- **Modified**: `src/components/map/MapView.tsx` — replaces `(window as any).google` with properly typed `window.google`

No logic changes. Types only.