### PR TITLE
fix(security): stop persisting chat messages to localStorage (closes #57)

### DIFF
--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -215,13 +215,14 @@ export const useAppStore = create<AppState>()(
     }),
     {
       name: "asksussi-prefs",
+      // Security: chat messages are intentionally excluded from persistence.
+      // They may contain sensitive user input that must not survive browser sessions.
+      // Only non-sensitive UI preferences are persisted here.
       partialize: (state) => ({
         ttsEnabled: state.ttsEnabled,
         activePanel: state.activePanel,
         onboardingDismissed: state.onboardingDismissed,
         introDismissed: state.introDismissed,
-        chatMessages: state.chatMessages,
-        conversationId: state.conversationId,
       }),
     }
   )


### PR DESCRIPTION
## Summary

- **Removes `chatMessages` and `conversationId` from Zustand persist `partialize`** in `src/store/app-store.ts`. Chat messages may contain sensitive user input and should not survive browser sessions via localStorage.
- Non-sensitive UI preferences (`ttsEnabled`, `activePanel`, `onboardingDismissed`, `introDismissed`) remain persisted.
- Added security comment explaining why chat state is excluded from persistence.

Closes #57