### PR TITLE
feat: integrate 147 new Active Ageing Centres (closes #46)

### DIFF
--- a/src/lib/maps/campus-pois.ts
+++ b/src/lib/maps/campus-pois.ts
@@ -1,5 +1,6 @@
 import type { POI } from "@/types";
 import { ACTIVE_AGEING_CENTRES } from "./active-ageing-centres";
+import { ACTIVE_AGEING_CENTRES_NEW } from "./active-ageing-centres-new";
 import { AIC_OFFICES } from "./aic-offices";
 
 export const CAMPUS_CENTER = { lat: 1.3299, lng: 103.7764 };
@@ -526,6 +527,7 @@ export const CAMPUS_POIS: POI[] = [
 
   // ── Active Ageing Centres ──────────────────────────────────
   ...ACTIVE_AGEING_CENTRES,
+  ...ACTIVE_AGEING_CENTRES_NEW,
 ];
 
 export function findPOI(query: string): POI | undefined {


### PR DESCRIPTION
## Summary

- Import `ACTIVE_AGEING_CENTRES_NEW` (147 POIs) from `src/lib/maps/active-ageing-centres-new.ts` into `src/lib/maps/campus-pois.ts`
- Merge new entries into the `CAMPUS_POIS` array alongside existing AACs
- Zero duplicate IDs or names between the existing and new datasets — no deduplication needed

## Changes

**`src/lib/maps/campus-pois.ts`** (2 lines added):
1. Added import: `import { ACTIVE_AGEING_CENTRES_NEW } from "./active-ageing-centres-new"`
2. Spread `...ACTIVE_AGEING_CENTRES_NEW` into `CAMPUS_POIS` after existing `...ACTIVE_AGEING_CENTRES`

## Verification

- Both files already typed as `POI[]` — interface-compatible
- Confirmed 0 ID collisions and 0 name collisions between old and new datasets
- `npx tsc --noEmit` shows only pre-existing errors (missing `node_modules`)
- `npx vitest run` cannot run (missing `node_modules`) — CI will validate on install

Closes #46