### PR TITLE
fix(chat): update API route for AI SDK v3 UIMessage format

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,20 +1,12 @@
-import { streamText, stepCountIs } from "ai";
-import { z } from "zod";
+import { convertToModelMessages, streamText, stepCountIs, UIMessage } from "ai";
 import { google } from "@/lib/ai/provider";
 import { SYSTEM_PROMPT } from "@/lib/ai/system-prompt";
 import { tools } from "@/lib/ai/tools";
 
-const messageSchema = z.object({
-  role: z.enum(["user", "assistant"]),
-  content: z.string().max(2000),
-});
-
-const chatRequestSchema = z.object({
-  messages: z.array(messageSchema).min(1).max(20),
-});
+export const maxDuration = 30;
 
 export async function POST(req: Request) {
-  let body: unknown;
+  let body: { messages: UIMessage[] };
   try {
     body = await req.json();
   } catch {
@@ -23,17 +15,10 @@ export async function POST(req: Request) {
     });
   }
 
-  const parsed = chatRequestSchema.safeParse(body);
-  if (!parsed.success) {
-    return new Response(JSON.stringify({ error: "Invalid request" }), {
-      status: 400,
-    });
-  }
-
   const result = streamText({
     model: google("gemini-3.1-flash-lite-preview"),
     system: SYSTEM_PROMPT,
-    messages: parsed.data.messages,
+    messages: await convertToModelMessages(body.messages),
     tools,
     stopWhen: stepCountIs(5),
   });


### PR DESCRIPTION
## Summary

- Remove outdated Zod validation schema (`messageSchema`, `chatRequestSchema`) from `/api/chat/route.ts` that rejected the parts-based `UIMessage` format sent by `@ai-sdk/react` v3
- Use `convertToModelMessages()` to properly convert client-side `UIMessage[]` to server-side `ModelMessage[]` before passing to `streamText()`
- Add `maxDuration = 30` export for streaming timeout

## Root Cause

The `useChat` hook from `@ai-sdk/react` v3.0.118 sends messages in the new UI Message format with `parts` arrays, `id`, and `createdAt` fields. The Zod schema was still validating against the old `{ role: string, content: string }` flat format, causing every chat message to fail with HTTP 400 "Invalid request".

## Verification

- ✅ `npm run lint` — 0 errors
- ✅ `npm run build` — exit 0
- ✅ `npm test` — 453 tests pass (50 files)
- ✅ curl: UIMessage format → HTTP 200, streaming Gemini response
- ✅ curl: malformed JSON → HTTP 400 `{"error":"Invalid JSON"}`
- ✅ Playwright: "Hello, what can you help me with?" → full assistant response
- ✅ Playwright: "Where is the library?" → tool call (navigate_to) worked, returned Block C Level 2 details

## Files Changed

- `src/app/api/chat/route.ts` — 4 insertions, 19 deletions