### PR TITLE
feat(1d): Singlish + medical adaptation phrase list for STT biasing

### DIFF
--- a/src/data/singlishAdaptation.ts
+++ b/src/data/singlishAdaptation.ts
@@ -1,0 +1,50 @@
+export const singlishParticles = [
+  "lah", "leh", "loh", "lor", "meh", "sia", "hor",
+  "ah", "wah", "kan", "one", "nia",
+];
+
+export const singlishExclamations = [
+  "alamak", "shiok", "aiyoh", "aiyo", "wah lau",
+  "die die", "jialat", "sian", "bo jio",
+];
+
+export const singlishGrammar = [
+  "cannot", "can can", "already", "got", "is it",
+  "how come", "never mind", "last time", "next time",
+  "still got", "no more", "so far so good",
+];
+
+export const medicalTerms = [
+  "dementia", "incontinence", "dysphagia", "polypharmacy",
+  "physiotherapy", "occupational therapy", "geriatrician",
+  "palliative", "comorbidity", "delirium", "sarcopenia",
+  "osteoporosis", "hypertension", "diabetes", "stroke",
+  "Parkinsons", "Alzheimers",
+];
+
+export const cgaTerms = [
+  "NRIC", "ACP", "AMD", "LPA", "ADL", "IADL",
+  "CPR", "DNR", "MMSE", "AMT", "GDS", "MNA",
+  "Barthel", "Lawton", "Tinetti", "FRAIL",
+  "caregiver", "walker", "wheelchair", "commode",
+  "feeding tube", "nasogastric",
+];
+
+export const singaporePlaces = [
+  "polyclinic", "void deck", "HDB", "MRT", "NTUC",
+  "SGH", "NUH", "TTSH", "CGH", "KKH", "KTPH",
+  "AH", "Changi", "Tan Tock Seng", "Mount Elizabeth",
+  "Woodlands", "Tampines", "Jurong", "Bedok",
+];
+
+/** Combined list for Google STT phrase biasing */
+export function getAdaptationPhrases(): { value: string; boost?: number }[] {
+  return [
+    ...medicalTerms.map((v) => ({ value: v, boost: 10 })),
+    ...cgaTerms.map((v) => ({ value: v, boost: 15 })),
+    ...singlishParticles.map((v) => ({ value: v, boost: 5 })),
+    ...singlishExclamations.map((v) => ({ value: v, boost: 5 })),
+    ...singlishGrammar.map((v) => ({ value: v, boost: 3 })),
+    ...singaporePlaces.map((v) => ({ value: v, boost: 8 })),
+  ];
+}

--- a/tests/data/singlishAdaptation.test.ts
+++ b/tests/data/singlishAdaptation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  cgaTerms,
+  getAdaptationPhrases,
+  medicalTerms,
+  singaporePlaces,
+  singlishExclamations,
+  singlishGrammar,
+  singlishParticles,
+} from "@/data/singlishAdaptation";
+
+const allCategories = [
+  singlishParticles,
+  singlishExclamations,
+  singlishGrammar,
+  medicalTerms,
+  cgaTerms,
+  singaporePlaces,
+];
+
+describe("singlishAdaptation", () => {
+  it.each([
+    ["singlishParticles", singlishParticles],
+    ["singlishExclamations", singlishExclamations],
+    ["singlishGrammar", singlishGrammar],
+    ["medicalTerms", medicalTerms],
+    ["cgaTerms", cgaTerms],
+    ["singaporePlaces", singaporePlaces],
+  ])("%s is non-empty", (_name: string, list: string[]) => {
+    expect(list.length).toBeGreaterThan(0);
+  });
+
+  it("getAdaptationPhrases returns combined list with boosts", () => {
+    const phrases = getAdaptationPhrases();
+    const totalExpected = allCategories.reduce((sum, c) => sum + c.length, 0);
+
+    expect(phrases).toHaveLength(totalExpected);
+
+    for (const phrase of phrases) {
+      expect(phrase).toHaveProperty("value");
+      expect(typeof phrase.value).toBe("string");
+      expect(phrase).toHaveProperty("boost");
+      expect(typeof phrase.boost).toBe("number");
+    }
+  });
+
+  it("has no duplicates across categories", () => {
+    const all = allCategories.flat();
+    const unique = new Set(all);
+
+    expect(unique.size).toBe(all.length);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/data/singlishAdaptation.ts` with categorized phrase lists (Singlish particles, exclamations, grammar; medical/CGA terms; Singapore places) and `getAdaptationPhrases()` combining them with boost weights for Google STT phrase biasing
- Add comprehensive tests verifying non-empty categories, combined output with boosts, and no cross-category duplicates
- All 461 tests pass, lint clean