### PR TITLE
feat(3a): Singlish normalizer for clinical transcription

### DIFF
--- a/src/utils/singlishGlossary.ts
+++ b/src/utils/singlishGlossary.ts
@@ -1,0 +1,186 @@
+/**
+ * Singlish glossary for clinical transcription context.
+ *
+ * Exports structured glossary entries and a prompt-injectable string block
+ * that teaches the AI model how to interpret Singlish patterns in a
+ * healthcare / eldercare context.
+ */
+
+export interface GlossaryEntry {
+  term: string;
+  function: string;
+  examples: ReadonlyArray<{ singlish: string; standard: string }>;
+}
+
+export const SINGLISH_GLOSSARY: ReadonlyArray<GlossaryEntry> = [
+  {
+    term: "already",
+    function: "Completive aspect marker — indicates an action has been completed",
+    examples: [
+      { singlish: "I eat already", standard: "I have eaten" },
+      { singlish: "take medicine already", standard: "medication has been taken" },
+      { singlish: "fall down already", standard: "has already fallen" },
+    ],
+  },
+  {
+    term: "got",
+    function:
+      "Existential marker — indicates existence or possession, equivalent to 'there is' or 'have'",
+    examples: [
+      { singlish: "got pain", standard: "there is pain" },
+      { singlish: "got fall before", standard: "has had a fall before" },
+      { singlish: "got fever", standard: "has a fever" },
+    ],
+  },
+  {
+    term: "one",
+    function: "Sentence-final particle for emphasis or assertion",
+    examples: [
+      { singlish: "very pain one", standard: "it is really painful" },
+      { singlish: "always like that one", standard: "it is always like that" },
+      { singlish: "he very stubborn one", standard: "he is very stubborn" },
+    ],
+  },
+  {
+    term: "lah",
+    function:
+      "Sentence-final particle expressing emphasis, reassurance, or mild frustration",
+    examples: [
+      { singlish: "okay lah", standard: "it is okay" },
+      { singlish: "cannot walk lah", standard: "unable to walk" },
+      { singlish: "no choice lah", standard: "there is no choice" },
+    ],
+  },
+  {
+    term: "leh",
+    function:
+      "Sentence-final particle expressing uncertainty, suggestion, or mild assertion",
+    examples: [
+      { singlish: "like that how leh", standard: "what should we do then" },
+      { singlish: "pain leh", standard: "it is painful" },
+    ],
+  },
+  {
+    term: "lor",
+    function:
+      "Sentence-final particle expressing resignation or acceptance",
+    examples: [
+      { singlish: "take medicine lor", standard: "just take the medicine then" },
+      { singlish: "no choice lor", standard: "there is no choice" },
+    ],
+  },
+  {
+    term: "meh",
+    function: "Sentence-final particle expressing doubt or surprise",
+    examples: [
+      { singlish: "really meh", standard: "is that really so" },
+      { singlish: "got problem meh", standard: "is there a problem" },
+    ],
+  },
+  {
+    term: "hor",
+    function:
+      "Sentence-final particle seeking agreement or used as a discourse marker",
+    examples: [
+      { singlish: "this one hor, very pain", standard: "this one, it is very painful" },
+      { singlish: "you know hor", standard: "you know, right" },
+    ],
+  },
+  {
+    term: "can",
+    function:
+      "Used alone as affirmation; doubled ('can can') for enthusiastic agreement",
+    examples: [
+      { singlish: "can", standard: "yes / that is fine" },
+      { singlish: "can can", standard: "yes, absolutely" },
+      { singlish: "can walk", standard: "is able to walk" },
+    ],
+  },
+  {
+    term: "never",
+    function:
+      "Often means 'did not' (past tense negation), not necessarily 'never ever'",
+    examples: [
+      { singlish: "I never eat", standard: "I did not eat" },
+      { singlish: "never take medicine", standard: "did not take medication" },
+      { singlish: "never go doctor", standard: "did not visit the doctor" },
+    ],
+  },
+  {
+    term: "very",
+    function:
+      "Intensifier used more broadly than in standard English, sometimes without an adjective following",
+    examples: [
+      { singlish: "very pain", standard: "very painful" },
+      { singlish: "very cannot", standard: "really unable to" },
+    ],
+  },
+  {
+    term: "until",
+    function: "Indicates consequence or extent, often meaning 'to the point that'",
+    examples: [
+      { singlish: "pain until cannot walk", standard: "in so much pain that walking is not possible" },
+      { singlish: "cry until eyes swollen", standard: "cried so much that eyes are swollen" },
+    ],
+  },
+] as const;
+
+/**
+ * Singlish particles that appear at sentence boundaries.
+ * Used for detection and stripping in clinical normalization.
+ */
+export const SINGLISH_PARTICLES = [
+  "lah",
+  "leh",
+  "lor",
+  "loh",
+  "meh",
+  "hor",
+  "ah",
+  "sia",
+  "seh",
+  "wor",
+  "hah",
+  "mah",
+  "ar",
+  "one",
+] as const;
+
+export type SinglishParticle = (typeof SINGLISH_PARTICLES)[number];
+
+/**
+ * Prompt-injectable glossary string for AI system prompts.
+ *
+ * This block can be concatenated directly into a system prompt to give the
+ * model contextual understanding of Singlish expressions in clinical /
+ * eldercare conversations.
+ */
+export const SINGLISH_GLOSSARY_PROMPT = `## Singlish Language Context (Clinical Transcription)
+
+When processing transcripts from Singaporean patients or caregivers, be aware of Singlish (Singapore Colloquial English) patterns. Interpret them correctly rather than literally.
+
+### Key Patterns
+
+${SINGLISH_GLOSSARY.map(
+  (entry) =>
+    `**"${entry.term}"** — ${entry.function}\n${entry.examples
+      .map((ex) => `  - "${ex.singlish}" means "${ex.standard}"`)
+      .join("\n")}`,
+).join("\n\n")}
+
+### Sentence-Final Particles
+
+The following particles appear at the end of sentences and carry pragmatic (not lexical) meaning. They convey tone, emphasis, or attitude but do not change the factual content:
+${SINGLISH_PARTICLES.map((p) => `- "${p}"`).join(", ")}
+
+When generating clinical notes, strip these particles and rephrase in standard medical English while preserving all factual information.
+
+### Important Notes
+
+1. "Never" often means "did not" (past tense), not "never ever". Ask for clarification when the distinction matters clinically.
+2. "Already" signals completion, not timing. "Take medicine already" = "medication has been taken".
+3. "Got" is existential. "Got pain" = "there is pain", not "obtained pain".
+4. "Can can" (doubled) = enthusiastic yes. Single "can" = standard agreement.
+5. "Very" + noun is valid Singlish. "Very pain" = "very painful".
+6. Code-switching (mixing English with Mandarin/Malay/Tamil) is common. Preserve untranslatable terms and flag them.
+`;

--- a/src/utils/singlishNormalizer.ts
+++ b/src/utils/singlishNormalizer.ts
@@ -1,0 +1,146 @@
+import { SINGLISH_PARTICLES, type SinglishParticle } from "./singlishGlossary";
+
+export interface NormalizedResult {
+  normalized: string;
+  clinical: string;
+  detectedParticles: SinglishParticle[];
+  confidence: number;
+}
+
+interface ClinicalPattern {
+  pattern: RegExp;
+  replacement: string;
+}
+
+const CLINICAL_PATTERNS: ReadonlyArray<ClinicalPattern> = [
+  // --- Mobility / falls ---
+  { pattern: /\bcannot walk\b/gi, replacement: "unable to walk" },
+  { pattern: /\bcannot move\b/gi, replacement: "unable to move" },
+  { pattern: /\bcannot stand\b/gi, replacement: "unable to stand" },
+  { pattern: /\bgot fall before\b/gi, replacement: "has history of falls" },
+  { pattern: /\bgot fall down before\b/gi, replacement: "has history of falls" },
+  { pattern: /\bfall down already\b/gi, replacement: "has fallen" },
+  { pattern: /\balways fall\b/gi, replacement: "experiences frequent falls" },
+  { pattern: /\balways fall down\b/gi, replacement: "experiences frequent falls" },
+
+  // --- Medication ---
+  { pattern: /\btake medicine already\b/gi, replacement: "medication taken" },
+  { pattern: /\beat medicine already\b/gi, replacement: "medication taken" },
+  { pattern: /\bnever take medicine\b/gi, replacement: "did not take medication" },
+  { pattern: /\bnever eat medicine\b/gi, replacement: "did not take medication" },
+  { pattern: /\bforget take medicine\b/gi, replacement: "missed medication" },
+  { pattern: /\bforget eat medicine\b/gi, replacement: "missed medication" },
+
+  // --- Pain ---
+  { pattern: /\bvery pain one\b/gi, replacement: "reports significant pain" },
+  { pattern: /\bvery pain\b/gi, replacement: "reports significant pain" },
+  { pattern: /\bgot pain\b/gi, replacement: "reports pain" },
+  { pattern: /\bpain until cannot\b/gi, replacement: "pain severe enough to prevent" },
+  { pattern: /\bhere pain\b/gi, replacement: "pain at this location" },
+  { pattern: /\bwhere pain\b/gi, replacement: "location of pain" },
+  { pattern: /\bvery the pain\b/gi, replacement: "reports severe pain" },
+
+  // --- Cognition / memory ---
+  { pattern: /\balways forget things?\b/gi, replacement: "reports memory issues" },
+  { pattern: /\balways forget\b/gi, replacement: "reports memory issues" },
+  { pattern: /\bcannot remember\b/gi, replacement: "reports difficulty with recall" },
+
+  // --- General health ---
+  { pattern: /\bgot fever\b/gi, replacement: "reports fever" },
+  { pattern: /\bgot cough\b/gi, replacement: "reports cough" },
+  { pattern: /\bgot headache\b/gi, replacement: "reports headache" },
+  { pattern: /\bgot rash\b/gi, replacement: "reports rash" },
+  { pattern: /\bgot diarrhea\b/gi, replacement: "reports diarrhea" },
+  { pattern: /\balready eat\b/gi, replacement: "has eaten" },
+  { pattern: /\bnever eat\b/gi, replacement: "did not eat" },
+  { pattern: /\bnever go doctor\b/gi, replacement: "did not visit the doctor" },
+  { pattern: /\bnever go hospital\b/gi, replacement: "did not visit the hospital" },
+  { pattern: /\bnever sleep\b/gi, replacement: "did not sleep" },
+  { pattern: /\bcannot sleep\b/gi, replacement: "reports insomnia" },
+
+  // --- Existential "got" (generic fallback — must be AFTER specific "got X" patterns) ---
+  { pattern: /\bgot ([a-z]+)\b/gi, replacement: "has $1" },
+
+  // --- Completive "already" (generic fallback) ---
+  { pattern: /\b(\w+)\s+already\b/gi, replacement: "has $1" },
+];
+
+const PARTICLE_REGEX = new RegExp(
+  `\\b(${SINGLISH_PARTICLES.join("|")})\\b`,
+  "gi",
+);
+
+function detectParticles(text: string): SinglishParticle[] {
+  const found = new Set<SinglishParticle>();
+  const words = text.toLowerCase().split(/\s+/);
+
+  for (const word of words) {
+    const cleaned = word.replace(/[^a-z]/g, "");
+    if ((SINGLISH_PARTICLES as ReadonlyArray<string>).includes(cleaned)) {
+      found.add(cleaned as SinglishParticle);
+    }
+  }
+
+  return [...found].sort();
+}
+
+function stripParticles(text: string): string {
+  return text
+    .replace(PARTICLE_REGEX, "")
+    .replace(/\s{2,}/g, " ")
+    .replace(/\s+([.,!?])/g, "$1")
+    .trim();
+}
+
+function applyClinicalPatterns(text: string): string {
+  let result = text;
+  for (const { pattern, replacement } of CLINICAL_PATTERNS) {
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}
+
+function computeConfidence(
+  original: string,
+  detectedParticles: SinglishParticle[],
+  clinical: string,
+): number {
+  if (original.trim().length === 0) return 0;
+
+  const wordCount = original.trim().split(/\s+/).length;
+  const particleCount = detectedParticles.length;
+  const wasTransformed = clinical !== original;
+
+  let score = 0;
+
+  if (particleCount > 0) score += Math.min(particleCount * 0.15, 0.45);
+  if (wasTransformed) score += 0.35;
+  if (wordCount >= 3) score += 0.1;
+  if (wordCount >= 6) score += 0.1;
+
+  return Math.min(Math.round(score * 100) / 100, 1);
+}
+
+export function normalizeSinglish(transcript: string): NormalizedResult {
+  if (!transcript || transcript.trim().length === 0) {
+    return {
+      normalized: "",
+      clinical: "",
+      detectedParticles: [],
+      confidence: 0,
+    };
+  }
+
+  const trimmed = transcript.trim().replace(/\s+/g, " ");
+  const detectedParticles = detectParticles(trimmed);
+  const normalized = stripParticles(trimmed);
+  const clinical = applyClinicalPatterns(normalized);
+  const confidence = computeConfidence(trimmed, detectedParticles, clinical);
+
+  return {
+    normalized,
+    clinical,
+    detectedParticles,
+    confidence,
+  };
+}

--- a/tests/utils/singlishNormalizer.test.ts
+++ b/tests/utils/singlishNormalizer.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSinglish } from "@/utils/singlishNormalizer";
+import {
+  SINGLISH_GLOSSARY,
+  SINGLISH_GLOSSARY_PROMPT,
+  SINGLISH_PARTICLES,
+} from "@/utils/singlishGlossary";
+
+describe("normalizeSinglish", () => {
+  describe("particle detection", () => {
+    it("detects 'lah' particle", () => {
+      const result = normalizeSinglish("cannot walk lah");
+      expect(result.detectedParticles).toContain("lah");
+    });
+
+    it("detects 'lor' particle", () => {
+      const result = normalizeSinglish("take medicine lor");
+      expect(result.detectedParticles).toContain("lor");
+    });
+
+    it("detects 'meh' particle", () => {
+      const result = normalizeSinglish("really meh");
+      expect(result.detectedParticles).toContain("meh");
+    });
+
+    it("detects 'hor' particle", () => {
+      const result = normalizeSinglish("this one hor, very pain");
+      expect(result.detectedParticles).toContain("hor");
+      expect(result.detectedParticles).toContain("one");
+    });
+
+    it("detects multiple particles in one sentence", () => {
+      const result = normalizeSinglish("you know hor, very pain lah, no choice lor");
+      expect(result.detectedParticles).toContain("hor");
+      expect(result.detectedParticles).toContain("lah");
+      expect(result.detectedParticles).toContain("lor");
+    });
+
+    it("returns particles in sorted order", () => {
+      const result = normalizeSinglish("okay lor, pain lah, really meh");
+      const sorted = [...result.detectedParticles].sort();
+      expect(result.detectedParticles).toEqual(sorted);
+    });
+
+    it("does not duplicate particles found multiple times", () => {
+      const result = normalizeSinglish("pain lah, really lah, okay lah");
+      const lahCount = result.detectedParticles.filter((p) => p === "lah").length;
+      expect(lahCount).toBe(1);
+    });
+  });
+
+  describe("normalized output", () => {
+    it("strips particles from output", () => {
+      const result = normalizeSinglish("cannot walk lah");
+      expect(result.normalized).toBe("cannot walk");
+    });
+
+    it("strips multiple particles", () => {
+      const result = normalizeSinglish("this one hor very pain lah");
+      expect(result.normalized).not.toContain("hor");
+      expect(result.normalized).not.toContain("lah");
+    });
+
+    it("preserves non-particle words", () => {
+      const result = normalizeSinglish("I take medicine already");
+      expect(result.normalized).toContain("take");
+      expect(result.normalized).toContain("medicine");
+    });
+
+    it("collapses extra whitespace after stripping", () => {
+      const result = normalizeSinglish("pain  lah  very  bad");
+      expect(result.normalized).not.toMatch(/\s{2,}/);
+    });
+  });
+
+  describe("clinical normalization", () => {
+    it("converts 'cannot walk lah' to clinical language", () => {
+      const result = normalizeSinglish("cannot walk lah");
+      expect(result.clinical).toBe("unable to walk");
+    });
+
+    it("converts 'got fall before' to clinical language", () => {
+      const result = normalizeSinglish("got fall before");
+      expect(result.clinical).toBe("has history of falls");
+    });
+
+    it("converts 'take medicine already' to clinical language", () => {
+      const result = normalizeSinglish("take medicine already");
+      expect(result.clinical).toBe("medication taken");
+    });
+
+    it("converts 'very pain one' to clinical language", () => {
+      const result = normalizeSinglish("very pain one");
+      expect(result.clinical).toBe("reports significant pain");
+    });
+
+    it("converts 'always forget things' to clinical language", () => {
+      const result = normalizeSinglish("always forget things");
+      expect(result.clinical).toBe("reports memory issues");
+    });
+
+    it("converts 'never take medicine' to clinical language", () => {
+      const result = normalizeSinglish("never take medicine");
+      expect(result.clinical).toBe("did not take medication");
+    });
+
+    it("converts 'got fever' to clinical language", () => {
+      const result = normalizeSinglish("got fever");
+      expect(result.clinical).toBe("reports fever");
+    });
+
+    it("converts 'cannot sleep' to clinical language", () => {
+      const result = normalizeSinglish("cannot sleep");
+      expect(result.clinical).toBe("reports insomnia");
+    });
+
+    it("handles multiple clinical patterns in one sentence", () => {
+      const result = normalizeSinglish("got fever and cannot sleep lah");
+      expect(result.clinical).toContain("reports fever");
+      expect(result.clinical).toContain("reports insomnia");
+    });
+
+    it("is case-insensitive for pattern matching", () => {
+      const result = normalizeSinglish("Cannot Walk LAH");
+      expect(result.clinical).toBe("unable to walk");
+    });
+  });
+
+  describe("confidence scoring", () => {
+    it("returns 0 for empty input", () => {
+      const result = normalizeSinglish("");
+      expect(result.confidence).toBe(0);
+    });
+
+    it("returns higher confidence when particles are detected", () => {
+      const withParticle = normalizeSinglish("pain lah");
+      const without = normalizeSinglish("pain");
+      expect(withParticle.confidence).toBeGreaterThan(without.confidence);
+    });
+
+    it("returns higher confidence when clinical patterns match", () => {
+      const clinical = normalizeSinglish("cannot walk");
+      const plain = normalizeSinglish("hello world");
+      expect(clinical.confidence).toBeGreaterThan(plain.confidence);
+    });
+
+    it("returns confidence between 0 and 1", () => {
+      const result = normalizeSinglish("cannot walk lah very pain one got fever");
+      expect(result.confidence).toBeGreaterThanOrEqual(0);
+      expect(result.confidence).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty string", () => {
+      const result = normalizeSinglish("");
+      expect(result.normalized).toBe("");
+      expect(result.clinical).toBe("");
+      expect(result.detectedParticles).toEqual([]);
+      expect(result.confidence).toBe(0);
+    });
+
+    it("handles whitespace-only input", () => {
+      const result = normalizeSinglish("   ");
+      expect(result.normalized).toBe("");
+      expect(result.clinical).toBe("");
+      expect(result.detectedParticles).toEqual([]);
+      expect(result.confidence).toBe(0);
+    });
+
+    it("handles standard English without Singlish", () => {
+      const result = normalizeSinglish("The patient has a headache");
+      expect(result.normalized).toBe("The patient has a headache");
+      expect(result.detectedParticles).toEqual([]);
+    });
+
+    it("handles Mandarin code-switching gracefully", () => {
+      const result = normalizeSinglish("很痛 lah cannot walk");
+      expect(result.detectedParticles).toContain("lah");
+      expect(result.clinical).toContain("unable to walk");
+    });
+
+    it("handles mixed Singlish and standard English", () => {
+      const result = normalizeSinglish(
+        "The patient got fall before and cannot walk lah",
+      );
+      expect(result.clinical).toContain("has history of falls");
+      expect(result.clinical).toContain("unable to walk");
+    });
+
+    it("preserves input meaning when no patterns match", () => {
+      const input = "scheduled appointment for Tuesday";
+      const result = normalizeSinglish(input);
+      expect(result.normalized).toBe(input);
+      expect(result.clinical).toBe(input);
+    });
+
+    it("handles very long input", () => {
+      const longInput = "got pain lah ".repeat(100).trim();
+      const result = normalizeSinglish(longInput);
+      expect(result.detectedParticles).toContain("lah");
+      expect(result.confidence).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe("singlishGlossary", () => {
+  it("exports a non-empty glossary array", () => {
+    expect(SINGLISH_GLOSSARY.length).toBeGreaterThan(0);
+  });
+
+  it("has examples for every glossary entry", () => {
+    for (const entry of SINGLISH_GLOSSARY) {
+      expect(entry.examples.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("exports a non-empty particles array", () => {
+    expect(SINGLISH_PARTICLES.length).toBeGreaterThan(0);
+  });
+
+  it("includes common particles", () => {
+    expect(SINGLISH_PARTICLES).toContain("lah");
+    expect(SINGLISH_PARTICLES).toContain("lor");
+    expect(SINGLISH_PARTICLES).toContain("meh");
+    expect(SINGLISH_PARTICLES).toContain("hor");
+  });
+
+  it("exports a prompt string containing glossary content", () => {
+    expect(SINGLISH_GLOSSARY_PROMPT).toContain("Singlish");
+    expect(SINGLISH_GLOSSARY_PROMPT).toContain("already");
+    expect(SINGLISH_GLOSSARY_PROMPT).toContain("got");
+    expect(SINGLISH_GLOSSARY_PROMPT).toContain("lah");
+  });
+
+  it("prompt string includes clinical context header", () => {
+    expect(SINGLISH_GLOSSARY_PROMPT).toContain("Clinical Transcription");
+  });
+
+  it("every glossary entry appears in the prompt string", () => {
+    for (const entry of SINGLISH_GLOSSARY) {
+      expect(SINGLISH_GLOSSARY_PROMPT).toContain(entry.term);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **singlishGlossary.ts**: Structured glossary of 12 Singlish linguistic patterns (particles, aspect markers, existential markers) with examples, a 14-particle detection list, and a prompt-injectable string block for AI system prompts
- **singlishNormalizer.ts**: `normalizeSinglish()` function that detects Singlish particles, maps 35+ Singlish phrase patterns to clinical language (e.g. "cannot walk lah" → "unable to walk", "got fall before" → "has history of falls"), and returns a confidence score
- **39 tests** covering particle detection, clinical normalization mappings, confidence scoring, and edge cases (empty input, English-only, Mandarin code-switching)

## Files Changed

| File | Description |
|------|-------------|
| `src/utils/singlishGlossary.ts` | Glossary entries, particle list, AI prompt string |
| `src/utils/singlishNormalizer.ts` | `normalizeSinglish()` with `NormalizedResult` interface |
| `tests/utils/singlishNormalizer.test.ts` | 39 tests across 6 describe blocks |

## Verification

- ✅ ESLint: 0 errors
- ✅ Vitest: 492/492 tests pass (51 files, 0 regressions)