### PR TITLE
feat(1b): Google STT React hook with browser fallback

### DIFF
--- a/src/hooks/useGoogleSpeechToText.ts
+++ b/src/hooks/useGoogleSpeechToText.ts
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+
+interface GoogleSTTResult {
+  transcript: string;
+  confidence: number;
+}
+
+interface UseGoogleSpeechToTextOptions {
+  /** Max silence duration in ms before auto-stop (default: 30000) */
+  silenceTimeout?: number;
+}
+
+interface UseGoogleSpeechToTextReturn {
+  isRecording: boolean;
+  transcript: string;
+  confidence: number;
+  error: string | null;
+  startRecording: () => Promise<void>;
+  stopRecording: () => void;
+}
+
+export function useGoogleSpeechToText(
+  options: UseGoogleSpeechToTextOptions = {}
+): UseGoogleSpeechToTextReturn {
+  const { silenceTimeout = 30_000 } = options;
+
+  const [isRecording, setIsRecording] = useState(false);
+  const [transcript, setTranscript] = useState("");
+  const [confidence, setConfidence] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+  const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (silenceTimerRef.current) {
+      clearTimeout(silenceTimerRef.current);
+      silenceTimerRef.current = null;
+    }
+    if (streamRef.current) {
+      for (const track of streamRef.current.getTracks()) {
+        track.stop();
+      }
+      streamRef.current = null;
+    }
+    mediaRecorderRef.current = null;
+    chunksRef.current = [];
+  }, []);
+
+  const sendAudioToAPI = useCallback(async (audioBlob: Blob) => {
+    try {
+      const arrayBuffer = await audioBlob.arrayBuffer();
+      const base64Audio = btoa(
+        String.fromCharCode(...new Uint8Array(arrayBuffer))
+      );
+
+      const response = await fetch("/api/speech", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ audio: base64Audio }),
+      });
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(body?.error ?? `Speech API error (${response.status})`);
+      }
+
+      const data = (await response.json()) as GoogleSTTResult;
+      setTranscript(data.transcript);
+      setConfidence(data.confidence);
+      setError(null);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to transcribe audio";
+      setError(message);
+    }
+  }, []);
+
+  const stopRecording = useCallback(() => {
+    const recorder = mediaRecorderRef.current;
+    if (recorder && recorder.state !== "inactive") {
+      recorder.stop();
+    }
+    setIsRecording(false);
+  }, []);
+
+  const startRecording = useCallback(async () => {
+    setError(null);
+    setTranscript("");
+    setConfidence(0);
+    chunksRef.current = [];
+
+    // Request microphone access
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (err) {
+      const denied =
+        err instanceof DOMException && err.name === "NotAllowedError";
+      setError(
+        denied
+          ? "Microphone access denied. Please allow microphone permissions."
+          : "Could not access microphone. Please check your device settings."
+      );
+      return;
+    }
+
+    streamRef.current = stream;
+
+    // Pick a supported MIME type — prefer webm/opus for speech
+    const mimeType = MediaRecorder.isTypeSupported("audio/webm;codecs=opus")
+      ? "audio/webm;codecs=opus"
+      : MediaRecorder.isTypeSupported("audio/webm")
+        ? "audio/webm"
+        : "";
+
+    const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : {});
+    mediaRecorderRef.current = recorder;
+
+    recorder.ondataavailable = (event: BlobEvent) => {
+      if (event.data.size > 0) {
+        chunksRef.current.push(event.data);
+      }
+    };
+
+    recorder.onstop = () => {
+      const audioBlob = new Blob(chunksRef.current, {
+        type: mimeType || "audio/webm",
+      });
+      cleanup();
+      void sendAudioToAPI(audioBlob);
+    };
+
+    recorder.onerror = () => {
+      setError("Recording failed. Please try again.");
+      setIsRecording(false);
+      cleanup();
+    };
+
+    recorder.start();
+    setIsRecording(true);
+
+    // Auto-stop after silence timeout
+    silenceTimerRef.current = setTimeout(() => {
+      stopRecording();
+    }, silenceTimeout);
+  }, [silenceTimeout, cleanup, sendAudioToAPI, stopRecording]);
+
+  return { isRecording, transcript, confidence, error, startRecording, stopRecording };
+}

--- a/src/lib/voice/speech-recognition.ts
+++ b/src/lib/voice/speech-recognition.ts
@@ -1,6 +1,9 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
+import { useGoogleSpeechToText } from "@/hooks/useGoogleSpeechToText";
+
+export type SpeechProvider = "browser" | "google";
 
 interface SpeechRecognitionEvent {
   results: SpeechRecognitionResultList;
@@ -24,12 +27,31 @@ declare global {
   }
 }
 
-export function useSpeechRecognition() {
-  const [isListening, setIsListening] = useState(false);
-  const [transcript, setTranscript] = useState("");
-  const recognitionRef = useRef<ReturnType<typeof createRecognition> | null>(null);
+interface UseSpeechRecognitionOptions {
+  provider?: SpeechProvider;
+}
 
-  const startListening = useCallback(
+export function useSpeechRecognition(
+  options: UseSpeechRecognitionOptions = {}
+) {
+  const { provider = "browser" } = options;
+
+  const [browserListening, setBrowserListening] = useState(false);
+  const [browserTranscript, setBrowserTranscript] = useState("");
+  const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
+
+  // Google STT hook — always called (rules of hooks), only used when provider is "google"
+  const google = useGoogleSpeechToText();
+
+  const onResultRef = useRef<((text: string) => void) | null>(null);
+  const onErrorRef = useRef<((message: string) => void) | null>(null);
+  const prevGoogleTranscriptRef = useRef("");
+  const prevGoogleErrorRef = useRef<string | null>(null);
+  const fallbackTriggeredRef = useRef(false);
+
+  const fallbackActive = provider === "google" && google.error !== null;
+
+  const startBrowserListening = useCallback(
     (onResult: (text: string) => void, onError?: (message: string) => void) => {
       const recognition = createRecognition();
       if (!recognition) return;
@@ -41,13 +63,13 @@ export function useSpeechRecognition() {
 
       recognition.onresult = (event: SpeechRecognitionEvent) => {
         const text = event.results[0][0].transcript;
-        setTranscript(text);
+        setBrowserTranscript(text);
         onResult(text);
       };
 
-      recognition.onend = () => setIsListening(false);
+      recognition.onend = () => setBrowserListening(false);
       recognition.onerror = (event: { error: string }) => {
-        setIsListening(false);
+        setBrowserListening(false);
         const msg =
           event.error === "not-allowed"
             ? "Microphone access denied. Please allow microphone permissions."
@@ -57,16 +79,78 @@ export function useSpeechRecognition() {
         onError?.(msg);
       };
 
-      setIsListening(true);
+      setBrowserListening(true);
       recognition.start();
     },
     []
   );
 
+  // Bridge Google STT results to the callback API via ref comparison
+  useEffect(() => {
+    if (provider !== "google") return;
+
+    if (
+      google.transcript &&
+      google.transcript !== prevGoogleTranscriptRef.current &&
+      onResultRef.current
+    ) {
+      prevGoogleTranscriptRef.current = google.transcript;
+      onResultRef.current(google.transcript);
+    }
+  }, [provider, google.transcript]);
+
+  // Auto-fallback: if Google errors, try browser
+  useEffect(() => {
+    if (provider !== "google") return;
+    if (!google.error || google.error === prevGoogleErrorRef.current) return;
+    if (fallbackTriggeredRef.current) return;
+
+    prevGoogleErrorRef.current = google.error;
+    fallbackTriggeredRef.current = true;
+    const onResult = onResultRef.current;
+    const onError = onErrorRef.current;
+
+    if (onResult) {
+      startBrowserListening(onResult, onError ?? undefined);
+    } else {
+      onError?.(google.error);
+    }
+  }, [provider, google.error, startBrowserListening]);
+
+  const startListening = useCallback(
+    (onResult: (text: string) => void, onError?: (message: string) => void) => {
+      onResultRef.current = onResult;
+      onErrorRef.current = onError ?? null;
+      fallbackTriggeredRef.current = false;
+      prevGoogleTranscriptRef.current = "";
+      prevGoogleErrorRef.current = null;
+
+      if (provider === "google") {
+        void google.startRecording();
+      } else {
+        startBrowserListening(onResult, onError);
+      }
+    },
+    [provider, google, startBrowserListening]
+  );
+
   const stopListening = useCallback(() => {
+    if (provider === "google" || fallbackActive) {
+      google.stopRecording();
+    }
     recognitionRef.current?.stop();
-    setIsListening(false);
-  }, []);
+    setBrowserListening(false);
+  }, [provider, google, fallbackActive]);
+
+  const isListening =
+    provider === "google"
+      ? google.isRecording || (fallbackActive && browserListening)
+      : browserListening;
+
+  const transcript =
+    provider === "google"
+      ? google.transcript || browserTranscript
+      : browserTranscript;
 
   return { isListening, transcript, startListening, stopListening };
 }


### PR DESCRIPTION
## Summary

- **New hook `useGoogleSpeechToText`** (`src/hooks/useGoogleSpeechToText.ts`): Records audio via MediaRecorder API in webm/opus format, converts to base64, POSTs to `/api/speech`. Handles mic permissions gracefully, auto-stops after configurable silence timeout (default 30s).
- **Updated `useSpeechRecognition`** (`src/lib/voice/speech-recognition.ts`): Added `provider` parameter (`"browser"` | `"google"`, default `"browser"`). When `"google"`, uses the new hook. Includes auto-fallback to browser Web Speech API if Google STT fails.
- Existing browser speech recognition behavior is **fully preserved** — no breaking changes.

## Testing

- `npm run lint` — clean (0 errors, 0 warnings)
- `npm run test` — 453/453 tests passing