### PR TITLE
feat(4c): audio denoising and preprocessing config

### DIFF
--- a/src/lib/voice/audio-config.ts
+++ b/src/lib/voice/audio-config.ts
@@ -1,0 +1,27 @@
+/** Google Cloud STT optimal sample rate. */
+export const AUDIO_SAMPLE_RATE = 16_000;
+
+/** Mono — single-speaker STT needs one channel. */
+export const AUDIO_CHANNEL_COUNT = 1;
+
+/**
+ * `MediaStreamConstraints` for speech capture in noisy eldercare environments.
+ *
+ * - `autoGainControl`  — normalises volume for soft-spoken users.
+ * - `noiseSuppression` — attenuates steady-state background noise.
+ * - `echoCancellation` — removes loudspeaker feedback loops.
+ * - `sampleRate`       — 16 kHz (Google STT preferred input).
+ * - `channelCount`     — mono for single-speaker STT.
+ */
+export function getMediaConstraints(): MediaStreamConstraints {
+  return {
+    audio: {
+      autoGainControl: true,
+      noiseSuppression: true,
+      echoCancellation: true,
+      sampleRate: AUDIO_SAMPLE_RATE,
+      channelCount: AUDIO_CHANNEL_COUNT,
+    },
+    video: false,
+  };
+}

--- a/tests/lib/voice/audio-config.test.ts
+++ b/tests/lib/voice/audio-config.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  AUDIO_SAMPLE_RATE,
+  AUDIO_CHANNEL_COUNT,
+  getMediaConstraints,
+} from "@/lib/voice/audio-config";
+
+describe("audio-config", () => {
+  it("exports a 16 kHz sample rate for Google STT", () => {
+    expect(AUDIO_SAMPLE_RATE).toBe(16_000);
+  });
+
+  it("exports mono channel count", () => {
+    expect(AUDIO_CHANNEL_COUNT).toBe(1);
+  });
+
+  describe("getMediaConstraints", () => {
+    it("returns constraints with video disabled", () => {
+      const constraints = getMediaConstraints();
+      expect(constraints.video).toBe(false);
+    });
+
+    it("enables autoGainControl for soft-spoken users", () => {
+      const { audio } = getMediaConstraints();
+      expect((audio as MediaTrackConstraints).autoGainControl).toBe(true);
+    });
+
+    it("enables noiseSuppression for background noise", () => {
+      const { audio } = getMediaConstraints();
+      expect((audio as MediaTrackConstraints).noiseSuppression).toBe(true);
+    });
+
+    it("enables echoCancellation for loudspeaker feedback", () => {
+      const { audio } = getMediaConstraints();
+      expect((audio as MediaTrackConstraints).echoCancellation).toBe(true);
+    });
+
+    it("sets sampleRate to AUDIO_SAMPLE_RATE (16 kHz)", () => {
+      const { audio } = getMediaConstraints();
+      expect((audio as MediaTrackConstraints).sampleRate).toBe(16_000);
+    });
+
+    it("sets channelCount to AUDIO_CHANNEL_COUNT (mono)", () => {
+      const { audio } = getMediaConstraints();
+      expect((audio as MediaTrackConstraints).channelCount).toBe(1);
+    });
+
+    it("returns a fresh object on each call (no shared state)", () => {
+      const a = getMediaConstraints();
+      const b = getMediaConstraints();
+      expect(a).not.toBe(b);
+      expect(a).toEqual(b);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/lib/voice/audio-config.ts` with `getMediaConstraints()` returning `MediaStreamConstraints` optimized for speech capture in noisy eldercare environments (AGC, noise suppression, echo cancellation enabled).
- Export `AUDIO_SAMPLE_RATE` (16 kHz) and `AUDIO_CHANNEL_COUNT` (mono) constants matching Google Cloud STT optimal input.
- Add comprehensive test suite (`tests/lib/voice/audio-config.test.ts`) — 8 tests covering all constraints, constants, and no-shared-state guarantee.

Lint clean, 462/462 tests pass.