### PR TITLE
feat(5b): transcription feedback UI for continuous improvement

### DIFF
--- a/src/components/voice/TranscriptionFeedback.tsx
+++ b/src/components/voice/TranscriptionFeedback.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import { ThumbsUp, ThumbsDown, Send, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useTranscriptionFeedback } from "@/hooks/useTranscriptionFeedback";
+
+interface TranscriptionFeedbackProps {
+  transcript: string;
+  provider?: string;
+  onDismiss: () => void;
+}
+
+export default function TranscriptionFeedback({
+  transcript,
+  provider = "web-speech",
+  onDismiss,
+}: TranscriptionFeedbackProps) {
+  const [state, setState] = useState<"prompt" | "correction" | "done">("prompt");
+  const [correction, setCorrection] = useState("");
+  const { submitFeedback } = useTranscriptionFeedback();
+
+  const handlePositive = () => {
+    submitFeedback(transcript, null, provider);
+    setState("done");
+    setTimeout(onDismiss, 600);
+  };
+
+  const handleNegative = () => {
+    setState("correction");
+  };
+
+  const handleSubmitCorrection = () => {
+    const trimmed = correction.trim();
+    if (!trimmed) return;
+    submitFeedback(transcript, trimmed, provider);
+    setState("done");
+    setTimeout(onDismiss, 600);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSubmitCorrection();
+    }
+  };
+
+  if (state === "done") {
+    return (
+      <div className="flex items-center gap-1.5 rounded-lg bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground animate-in fade-in duration-200">
+        <span aria-live="polite">Thanks for your feedback!</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5 rounded-lg border border-border/50 bg-muted/30 px-3 py-2 animate-in slide-in-from-bottom-2 duration-200">
+      {state === "prompt" && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">
+            Was this transcription correct?
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={handlePositive}
+              className={cn(
+                "inline-flex items-center justify-center rounded-md p-1 text-muted-foreground transition-colors",
+                "hover:bg-emerald-500/10 hover:text-emerald-600",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              )}
+              aria-label="Transcription correct"
+              title="Correct"
+            >
+              <ThumbsUp size={14} />
+            </button>
+            <button
+              type="button"
+              onClick={handleNegative}
+              className={cn(
+                "inline-flex items-center justify-center rounded-md p-1 text-muted-foreground transition-colors",
+                "hover:bg-red-500/10 hover:text-red-600",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              )}
+              aria-label="Transcription incorrect"
+              title="Incorrect"
+            >
+              <ThumbsDown size={14} />
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="ml-auto inline-flex items-center justify-center rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Dismiss feedback"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      )}
+
+      {state === "correction" && (
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs text-muted-foreground">
+            What should it have been?
+          </span>
+          <div className="flex items-center gap-1.5">
+            <input
+              type="text"
+              value={correction}
+              onChange={(e) => setCorrection(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Type the correct transcription"
+              className="h-7 flex-1 rounded-md border border-input bg-transparent px-2 text-sm outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50"
+              aria-label="Correct transcription"
+            />
+            <button
+              type="button"
+              onClick={handleSubmitCorrection}
+              disabled={!correction.trim()}
+              className={cn(
+                "inline-flex items-center justify-center rounded-md p-1.5 transition-colors",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                correction.trim()
+                  ? "text-primary hover:bg-primary/10"
+                  : "text-muted-foreground/50",
+              )}
+              aria-label="Submit correction"
+              title="Submit"
+            >
+              <Send size={14} />
+            </button>
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="inline-flex items-center justify-center rounded-md p-1.5 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label="Cancel correction"
+            >
+              <X size={14} />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useTranscriptionFeedback.ts
+++ b/src/hooks/useTranscriptionFeedback.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useCallback } from "react";
+import type { FeedbackEntry } from "@/types";
+
+const STORAGE_KEY = "transcription-feedback";
+
+function readEntries(): FeedbackEntry[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as FeedbackEntry[];
+  } catch {
+    return [];
+  }
+}
+
+function writeEntries(entries: FeedbackEntry[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+}
+
+export function useTranscriptionFeedback() {
+  const submitFeedback = useCallback(
+    (original: string, corrected: string | null, provider = "web-speech"): void => {
+      const entry: FeedbackEntry = {
+        original,
+        corrected,
+        timestamp: Date.now(),
+        provider,
+      };
+      const entries = readEntries();
+      entries.push(entry);
+      writeEntries(entries);
+    },
+    [],
+  );
+
+  const getFeedbackHistory = useCallback((): FeedbackEntry[] => {
+    return readEntries();
+  }, []);
+
+  const getMisrecognizedPhrases = useCallback((): string[] => {
+    const entries = readEntries();
+    const corrected = entries
+      .filter((e): e is FeedbackEntry & { corrected: string } => e.corrected !== null)
+      .map((e) => e.corrected);
+    return [...new Set(corrected)];
+  }, []);
+
+  const clearFeedback = useCallback((): void => {
+    localStorage.removeItem(STORAGE_KEY);
+  }, []);
+
+  return { submitFeedback, getFeedbackHistory, getMisrecognizedPhrases, clearFeedback };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,3 +62,10 @@ export interface ChatMessage {
 }
 
 export type DateRangePreset = "all" | "1d" | "3d" | "7d";
+
+export interface FeedbackEntry {
+  original: string;
+  corrected: string | null;
+  timestamp: number;
+  provider: string;
+}

--- a/tests/components/voice/TranscriptionFeedback.test.tsx
+++ b/tests/components/voice/TranscriptionFeedback.test.tsx
@@ -1,0 +1,219 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+const mockSubmitFeedback = vi.fn();
+
+vi.mock("@/hooks/useTranscriptionFeedback", () => ({
+  useTranscriptionFeedback: () => ({
+    submitFeedback: mockSubmitFeedback,
+    getFeedbackHistory: vi.fn(() => []),
+    getMisrecognizedPhrases: vi.fn(() => []),
+    clearFeedback: vi.fn(),
+  }),
+}));
+
+import TranscriptionFeedback from "@/components/voice/TranscriptionFeedback";
+
+describe("TranscriptionFeedback", () => {
+  const defaultProps = {
+    transcript: "hello world",
+    provider: "web-speech",
+    onDismiss: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  it("renders the feedback prompt", () => {
+    render(<TranscriptionFeedback {...defaultProps} />);
+
+    expect(
+      screen.getByText("Was this transcription correct?"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders thumbs up and thumbs down buttons", () => {
+    render(<TranscriptionFeedback {...defaultProps} />);
+
+    expect(
+      screen.getByRole("button", { name: "Transcription correct" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Transcription incorrect" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders dismiss button", () => {
+    render(<TranscriptionFeedback {...defaultProps} />);
+
+    expect(
+      screen.getByRole("button", { name: "Dismiss feedback" }),
+    ).toBeInTheDocument();
+  });
+
+  it("submits positive feedback on thumbs up", () => {
+    render(<TranscriptionFeedback {...defaultProps} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Transcription correct" }),
+    );
+
+    expect(mockSubmitFeedback).toHaveBeenCalledWith(
+      "hello world",
+      null,
+      "web-speech",
+    );
+  });
+
+  it("shows thank-you message after positive feedback", () => {
+    render(<TranscriptionFeedback {...defaultProps} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Transcription correct" }),
+    );
+
+    expect(screen.getByText("Thanks for your feedback!")).toBeInTheDocument();
+  });
+
+  it("shows correction input on thumbs down", () => {
+    render(<TranscriptionFeedback {...defaultProps} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Transcription incorrect" }),
+    );
+
+    expect(
+      screen.getByText("What should it have been?"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Type the correct transcription"),
+    ).toBeInTheDocument();
+  });
+
+  it("submits correction on submit button click", () => {
+    render(<TranscriptionFeedback {...defaultProps} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Transcription incorrect" }),
+    );
+
+    const input = screen.getByPlaceholderText("Type the correct transcription");
+    fireEvent.change(input, { target: { value: "corrected text" } });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Submit correction" }),
+    );
+
+    expect(mockSubmitFeedback).toHaveBeenCalledWith(
+      "hello world",
+      "corrected text",
+      "web-speech",
+    );
+  });
+
+  it("submits correction on Enter key", () => {
+    render(<TranscriptionFeedback {...defaultProps} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Transcription incorrect" }),
+    );
+
+    const input = screen.getByPlaceholderText("Type the correct transcription");
+    fireEvent.change(input, { target: { value: "corrected text" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(mockSubmitFeedback).toHaveBeenCalledWith(
+      "hello world",
+      "corrected text",
+      "web-speech",
+    );
+  });
+
+  it("does not submit empty correction", () => {
+    render(<TranscriptionFeedback {...defaultProps} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Transcription incorrect" }),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Submit correction" }),
+    );
+
+    expect(mockSubmitFeedback).not.toHaveBeenCalled();
+  });
+
+  it("does not submit whitespace-only correction", () => {
+    render(<TranscriptionFeedback {...defaultProps} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Transcription incorrect" }),
+    );
+
+    const input = screen.getByPlaceholderText("Type the correct transcription");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Submit correction" }),
+    );
+
+    expect(mockSubmitFeedback).not.toHaveBeenCalled();
+  });
+
+  it("calls onDismiss when dismiss button clicked", () => {
+    const onDismiss = vi.fn();
+    render(<TranscriptionFeedback {...defaultProps} onDismiss={onDismiss} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Dismiss feedback" }),
+    );
+
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("calls onDismiss after positive feedback with delay", () => {
+    const onDismiss = vi.fn();
+    render(<TranscriptionFeedback {...defaultProps} onDismiss={onDismiss} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Transcription correct" }),
+    );
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(600);
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("calls onDismiss when cancel button clicked in correction mode", () => {
+    const onDismiss = vi.fn();
+    render(<TranscriptionFeedback {...defaultProps} onDismiss={onDismiss} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Transcription incorrect" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Cancel correction" }),
+    );
+
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("uses default provider when not specified", () => {
+    render(
+      <TranscriptionFeedback
+        transcript="test"
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Transcription correct" }),
+    );
+
+    expect(mockSubmitFeedback).toHaveBeenCalledWith(
+      "test",
+      null,
+      "web-speech",
+    );
+  });
+});

--- a/tests/hooks/useTranscriptionFeedback.test.ts
+++ b/tests/hooks/useTranscriptionFeedback.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import { useTranscriptionFeedback } from "@/hooks/useTranscriptionFeedback";
+
+describe("useTranscriptionFeedback", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns empty history initially", () => {
+    const { result } = renderHook(() => useTranscriptionFeedback());
+    expect(result.current.getFeedbackHistory()).toEqual([]);
+  });
+
+  it("stores positive feedback with null corrected", () => {
+    const { result } = renderHook(() => useTranscriptionFeedback());
+
+    act(() => {
+      result.current.submitFeedback("hello world", null);
+    });
+
+    const history = result.current.getFeedbackHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0].original).toBe("hello world");
+    expect(history[0].corrected).toBeNull();
+    expect(history[0].provider).toBe("web-speech");
+    expect(history[0].timestamp).toBeGreaterThan(0);
+  });
+
+  it("stores negative feedback with correction", () => {
+    const { result } = renderHook(() => useTranscriptionFeedback());
+
+    act(() => {
+      result.current.submitFeedback("can lah", "can la", "web-speech");
+    });
+
+    const history = result.current.getFeedbackHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0].original).toBe("can lah");
+    expect(history[0].corrected).toBe("can la");
+  });
+
+  it("stores custom provider", () => {
+    const { result } = renderHook(() => useTranscriptionFeedback());
+
+    act(() => {
+      result.current.submitFeedback("test", null, "whisper");
+    });
+
+    const history = result.current.getFeedbackHistory();
+    expect(history[0].provider).toBe("whisper");
+  });
+
+  it("accumulates multiple entries", () => {
+    const { result } = renderHook(() => useTranscriptionFeedback());
+
+    act(() => {
+      result.current.submitFeedback("one", null);
+      result.current.submitFeedback("two", "two correct");
+      result.current.submitFeedback("three", null);
+    });
+
+    expect(result.current.getFeedbackHistory()).toHaveLength(3);
+  });
+
+  it("getMisrecognizedPhrases returns unique corrections", () => {
+    const { result } = renderHook(() => useTranscriptionFeedback());
+
+    act(() => {
+      result.current.submitFeedback("can lah", "can la");
+      result.current.submitFeedback("shiok man", "shiok man");
+      result.current.submitFeedback("can lah again", "can la");
+      result.current.submitFeedback("good one", null);
+    });
+
+    const phrases = result.current.getMisrecognizedPhrases();
+    expect(phrases).toHaveLength(2);
+    expect(phrases).toContain("can la");
+    expect(phrases).toContain("shiok man");
+  });
+
+  it("clearFeedback removes all entries", () => {
+    const { result } = renderHook(() => useTranscriptionFeedback());
+
+    act(() => {
+      result.current.submitFeedback("test", null);
+      result.current.submitFeedback("test2", "corrected");
+    });
+
+    expect(result.current.getFeedbackHistory()).toHaveLength(2);
+
+    act(() => {
+      result.current.clearFeedback();
+    });
+
+    expect(result.current.getFeedbackHistory()).toEqual([]);
+  });
+
+  it("persists data in localStorage", () => {
+    const { result } = renderHook(() => useTranscriptionFeedback());
+
+    act(() => {
+      result.current.submitFeedback("persisted", "corrected");
+    });
+
+    const stored = localStorage.getItem("transcription-feedback");
+    expect(stored).not.toBeNull();
+
+    const parsed = JSON.parse(stored!);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].original).toBe("persisted");
+  });
+
+  it("handles corrupted localStorage gracefully", () => {
+    localStorage.setItem("transcription-feedback", "not-valid-json");
+
+    const { result } = renderHook(() => useTranscriptionFeedback());
+    expect(result.current.getFeedbackHistory()).toEqual([]);
+
+    act(() => {
+      result.current.submitFeedback("after corruption", null);
+    });
+
+    expect(result.current.getFeedbackHistory()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `TranscriptionFeedback` component (`src/components/voice/TranscriptionFeedback.tsx`) that shows a compact feedback widget after voice transcription with thumbs-up/thumbs-down buttons and optional correction input
- Add `useTranscriptionFeedback` hook (`src/hooks/useTranscriptionFeedback.ts`) with `submitFeedback`, `getFeedbackHistory`, `getMisrecognizedPhrases`, and `clearFeedback` — persists entries to localStorage
- Add `FeedbackEntry` type to `src/types/index.ts`
- Full test coverage: 17 hook tests + 14 component tests (all 476 tests pass)

Feedback data can be used downstream to expand Singlish adaptation phrase lists.