### PR TITLE
feat(2c): A/B test infrastructure for STT comparison

### DIFF
--- a/src/hooks/useSTTComparison.ts
+++ b/src/hooks/useSTTComparison.ts
@@ -1,0 +1,240 @@
+"use client";
+
+import { useRef } from "react";
+
+export interface STTComparisonEntry {
+  sessionId: string;
+  utteranceId: string;
+  browserTranscript: string;
+  googleTranscript: string;
+  browserConfidence: number;
+  googleConfidence: number;
+  matchRate: number;
+  wer: number;
+  timestamp: number;
+}
+
+export interface STTComparisonStats {
+  totalComparisons: number;
+  averageMatchRate: number;
+  averageWER: number;
+  averageBrowserConfidence: number;
+  averageGoogleConfidence: number;
+  browserWinsCount: number;
+  googleWinsCount: number;
+  tiesCount: number;
+}
+
+export interface STTComparisonConfig {
+  /** Percentage of sessions that run dual STT (0–100). Default 10. */
+  samplingRate: number;
+  /** localStorage key for persisting comparison logs. */
+  storageKey: string;
+}
+
+interface SpeechRecognitionResult {
+  transcript: string;
+  confidence: number;
+}
+
+const DEFAULT_CONFIG: STTComparisonConfig = {
+  samplingRate: 10,
+  storageKey: "stt-comparison-log",
+};
+
+const SESSION_FLAG_KEY = "stt-comparison-enrolled";
+
+export function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, "")
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+/**
+ * WER = (substitutions + insertions + deletions) / referenceLength
+ * Uses Wagner–Fischer (Levenshtein) on word tokens.
+ * Returns 0 when both empty; 1 when reference is empty but hypothesis is not.
+ */
+export function calculateWER(hypothesis: string, reference: string): number {
+  const hyp = tokenize(hypothesis);
+  const ref = tokenize(reference);
+
+  if (ref.length === 0 && hyp.length === 0) return 0;
+  if (ref.length === 0) return 1;
+
+  const m = ref.length;
+  const n = hyp.length;
+
+  let prev = Array.from({ length: n + 1 }, (_, j) => j);
+  const curr = new Array<number>(n + 1);
+
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = ref[i - 1] === hyp[j - 1] ? 0 : 1;
+      curr[j] = Math.min(
+        prev[j] + 1,     // deletion
+        curr[j - 1] + 1, // insertion
+        prev[j - 1] + cost // substitution
+      );
+    }
+    prev = [...curr];
+  }
+
+  return Math.min(prev[n] / m, 1);
+}
+
+export function calculateMatchRate(a: string, b: string): number {
+  const tokensA = tokenize(a);
+  const tokensB = tokenize(b);
+
+  if (tokensA.length === 0 && tokensB.length === 0) return 1;
+  if (tokensA.length === 0 || tokensB.length === 0) return 0;
+
+  const setB = new Set(tokensB);
+  const matches = tokensA.filter((t) => setB.has(t)).length;
+
+  return matches / Math.max(tokensA.length, tokensB.length);
+}
+
+function readLog(storageKey: string): STTComparisonEntry[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(storageKey);
+    return raw ? (JSON.parse(raw) as STTComparisonEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeLog(storageKey: string, entries: STTComparisonEntry[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(entries));
+  } catch {
+    // Storage full — silently drop to avoid breaking the app
+  }
+}
+
+/**
+ * Session-sticky enrollment: decides once per session whether to participate
+ * in A/B testing, caching the result in sessionStorage so re-renders don't
+ * re-roll the dice.
+ */
+export function isSessionEnrolled(samplingRate: number): boolean {
+  if (typeof window === "undefined") return false;
+
+  const cached = sessionStorage.getItem(SESSION_FLAG_KEY);
+  if (cached !== null) return cached === "1";
+
+  const enrolled = Math.random() * 100 < samplingRate;
+  sessionStorage.setItem(SESSION_FLAG_KEY, enrolled ? "1" : "0");
+  return enrolled;
+}
+
+export function getComparisonStats(
+  storageKey: string = DEFAULT_CONFIG.storageKey
+): STTComparisonStats {
+  const entries = readLog(storageKey);
+
+  if (entries.length === 0) {
+    return {
+      totalComparisons: 0,
+      averageMatchRate: 0,
+      averageWER: 0,
+      averageBrowserConfidence: 0,
+      averageGoogleConfidence: 0,
+      browserWinsCount: 0,
+      googleWinsCount: 0,
+      tiesCount: 0,
+    };
+  }
+
+  let matchRateSum = 0;
+  let werSum = 0;
+  let browserConfSum = 0;
+  let googleConfSum = 0;
+  let browserWins = 0;
+  let googleWins = 0;
+  let ties = 0;
+
+  for (const e of entries) {
+    matchRateSum += e.matchRate;
+    werSum += e.wer;
+    browserConfSum += e.browserConfidence;
+    googleConfSum += e.googleConfidence;
+
+    if (e.browserConfidence > e.googleConfidence) browserWins++;
+    else if (e.googleConfidence > e.browserConfidence) googleWins++;
+    else ties++;
+  }
+
+  const n = entries.length;
+  return {
+    totalComparisons: n,
+    averageMatchRate: matchRateSum / n,
+    averageWER: werSum / n,
+    averageBrowserConfidence: browserConfSum / n,
+    averageGoogleConfidence: googleConfSum / n,
+    browserWinsCount: browserWins,
+    googleWinsCount: googleWins,
+    tiesCount: ties,
+  };
+}
+
+export function useSTTComparison(overrides?: Partial<STTComparisonConfig>) {
+  const config: STTComparisonConfig = { ...DEFAULT_CONFIG, ...overrides };
+  const utteranceCounter = useRef(0);
+  const sessionIdRef = useRef<string>(generateSessionId());
+
+  const enrolled = isSessionEnrolled(config.samplingRate);
+
+  const recordComparison = (
+    browser: SpeechRecognitionResult,
+    google: SpeechRecognitionResult
+  ): STTComparisonEntry | null => {
+    if (!enrolled) return null;
+
+    utteranceCounter.current += 1;
+
+    const entry: STTComparisonEntry = {
+      sessionId: sessionIdRef.current,
+      utteranceId: `${sessionIdRef.current}-${utteranceCounter.current}`,
+      browserTranscript: browser.transcript,
+      googleTranscript: google.transcript,
+      browserConfidence: browser.confidence,
+      googleConfidence: google.confidence,
+      matchRate: calculateMatchRate(browser.transcript, google.transcript),
+      wer: calculateWER(browser.transcript, google.transcript),
+      timestamp: Date.now(),
+    };
+
+    const log = readLog(config.storageKey);
+    log.push(entry);
+    writeLog(config.storageKey, log);
+
+    console.log("[STT A/B]", entry);
+
+    return entry;
+  };
+
+  const getStats = (): STTComparisonStats =>
+    getComparisonStats(config.storageKey);
+
+  const clearLog = () => {
+    writeLog(config.storageKey, []);
+  };
+
+  return {
+    enrolled,
+    recordComparison,
+    getStats,
+    clearLog,
+  };
+}
+
+function generateSessionId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
+}

--- a/tests/hooks/useSTTComparison.test.ts
+++ b/tests/hooks/useSTTComparison.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import {
+  tokenize,
+  calculateWER,
+  calculateMatchRate,
+  isSessionEnrolled,
+  getComparisonStats,
+  useSTTComparison,
+} from "@/hooks/useSTTComparison";
+import type { STTComparisonEntry } from "@/hooks/useSTTComparison";
+
+const TEST_STORAGE_KEY = "stt-comparison-test";
+
+function seedEntries(entries: STTComparisonEntry[]): void {
+  localStorage.setItem(TEST_STORAGE_KEY, JSON.stringify(entries));
+}
+
+function makeEntry(overrides: Partial<STTComparisonEntry> = {}): STTComparisonEntry {
+  return {
+    sessionId: "sess-1",
+    utteranceId: "sess-1-1",
+    browserTranscript: "hello world",
+    googleTranscript: "hello world",
+    browserConfidence: 0.9,
+    googleConfidence: 0.85,
+    matchRate: 1,
+    wer: 0,
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("tokenize", () => {
+  it("lowercases and splits on whitespace", () => {
+    expect(tokenize("Hello World")).toEqual(["hello", "world"]);
+  });
+
+  it("strips punctuation", () => {
+    expect(tokenize("It's a test, right?")).toEqual(["its", "a", "test", "right"]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(tokenize("")).toEqual([]);
+  });
+
+  it("handles multiple spaces", () => {
+    expect(tokenize("  spaced   out  ")).toEqual(["spaced", "out"]);
+  });
+});
+
+describe("calculateWER", () => {
+  it("returns 0 for identical strings", () => {
+    expect(calculateWER("hello world", "hello world")).toBe(0);
+  });
+
+  it("returns 0 when both are empty", () => {
+    expect(calculateWER("", "")).toBe(0);
+  });
+
+  it("returns 1 when reference is empty but hypothesis is not", () => {
+    expect(calculateWER("some words", "")).toBe(1);
+  });
+
+  it("calculates correct WER for substitutions", () => {
+    // "hello world" vs "hello earth" → 1 substitution / 2 ref words = 0.5
+    expect(calculateWER("hello earth", "hello world")).toBe(0.5);
+  });
+
+  it("calculates correct WER for insertions", () => {
+    // hyp="the big cat" vs ref="the cat" → 1 insertion / 2 ref = 0.5
+    expect(calculateWER("the big cat", "the cat")).toBe(0.5);
+  });
+
+  it("calculates correct WER for deletions", () => {
+    // hyp="the" vs ref="the cat" → 1 deletion / 2 ref = 0.5
+    expect(calculateWER("the", "the cat")).toBe(0.5);
+  });
+
+  it("caps WER at 1", () => {
+    expect(calculateWER("a b c d e f g h", "x")).toBeLessThanOrEqual(1);
+  });
+
+  it("is case-insensitive", () => {
+    expect(calculateWER("HELLO WORLD", "hello world")).toBe(0);
+  });
+});
+
+describe("calculateMatchRate", () => {
+  it("returns 1 for identical strings", () => {
+    expect(calculateMatchRate("hello world", "hello world")).toBe(1);
+  });
+
+  it("returns 1 for both empty", () => {
+    expect(calculateMatchRate("", "")).toBe(1);
+  });
+
+  it("returns 0 when one is empty", () => {
+    expect(calculateMatchRate("hello", "")).toBe(0);
+    expect(calculateMatchRate("", "hello")).toBe(0);
+  });
+
+  it("returns partial match for overlapping words", () => {
+    // "hello world" vs "hello earth" → 1 match / max(2, 2) = 0.5
+    expect(calculateMatchRate("hello world", "hello earth")).toBe(0.5);
+  });
+
+  it("returns 0 for completely different strings", () => {
+    expect(calculateMatchRate("foo bar", "baz qux")).toBe(0);
+  });
+});
+
+describe("isSessionEnrolled", () => {
+  beforeEach(() => {
+    sessionStorage.removeItem("stt-comparison-enrolled");
+  });
+
+  it("returns true when random < samplingRate and caches result", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.05);
+    expect(isSessionEnrolled(10)).toBe(true);
+    expect(sessionStorage.getItem("stt-comparison-enrolled")).toBe("1");
+    vi.restoreAllMocks();
+  });
+
+  it("returns false when random >= samplingRate and caches result", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    expect(isSessionEnrolled(10)).toBe(false);
+    expect(sessionStorage.getItem("stt-comparison-enrolled")).toBe("0");
+    vi.restoreAllMocks();
+  });
+
+  it("uses cached value on subsequent calls", () => {
+    sessionStorage.setItem("stt-comparison-enrolled", "1");
+    const randomSpy = vi.spyOn(Math, "random");
+    expect(isSessionEnrolled(0)).toBe(true);
+    expect(randomSpy).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it("enrolls at 100% rate", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.99);
+    expect(isSessionEnrolled(100)).toBe(true);
+    vi.restoreAllMocks();
+  });
+
+  it("never enrolls at 0% rate", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    expect(isSessionEnrolled(0)).toBe(false);
+    vi.restoreAllMocks();
+  });
+});
+
+describe("getComparisonStats", () => {
+  it("returns zeroed stats when no entries exist", () => {
+    const stats = getComparisonStats(TEST_STORAGE_KEY);
+    expect(stats.totalComparisons).toBe(0);
+    expect(stats.averageMatchRate).toBe(0);
+    expect(stats.averageWER).toBe(0);
+  });
+
+  it("calculates correct averages", () => {
+    seedEntries([
+      makeEntry({ browserConfidence: 0.9, googleConfidence: 0.8, matchRate: 1, wer: 0 }),
+      makeEntry({ browserConfidence: 0.7, googleConfidence: 0.9, matchRate: 0.5, wer: 0.5 }),
+    ]);
+
+    const stats = getComparisonStats(TEST_STORAGE_KEY);
+    expect(stats.totalComparisons).toBe(2);
+    expect(stats.averageMatchRate).toBe(0.75);
+    expect(stats.averageWER).toBe(0.25);
+    expect(stats.averageBrowserConfidence).toBe(0.8);
+    expect(stats.averageGoogleConfidence).toBeCloseTo(0.85);
+  });
+
+  it("counts wins correctly", () => {
+    seedEntries([
+      makeEntry({ browserConfidence: 0.9, googleConfidence: 0.8 }),
+      makeEntry({ browserConfidence: 0.7, googleConfidence: 0.9 }),
+      makeEntry({ browserConfidence: 0.8, googleConfidence: 0.8 }),
+    ]);
+
+    const stats = getComparisonStats(TEST_STORAGE_KEY);
+    expect(stats.browserWinsCount).toBe(1);
+    expect(stats.googleWinsCount).toBe(1);
+    expect(stats.tiesCount).toBe(1);
+  });
+});
+
+describe("useSTTComparison", () => {
+  beforeEach(() => {
+    sessionStorage.removeItem("stt-comparison-enrolled");
+    localStorage.removeItem(TEST_STORAGE_KEY);
+  });
+
+  it("returns enrolled=true when session is enrolled", () => {
+    sessionStorage.setItem("stt-comparison-enrolled", "1");
+    const { result } = renderHook(() =>
+      useSTTComparison({ storageKey: TEST_STORAGE_KEY, samplingRate: 100 })
+    );
+    expect(result.current.enrolled).toBe(true);
+  });
+
+  it("returns enrolled=false when session is not enrolled", () => {
+    sessionStorage.setItem("stt-comparison-enrolled", "0");
+    const { result } = renderHook(() =>
+      useSTTComparison({ storageKey: TEST_STORAGE_KEY, samplingRate: 0 })
+    );
+    expect(result.current.enrolled).toBe(false);
+  });
+
+  it("recordComparison returns null when not enrolled", () => {
+    sessionStorage.setItem("stt-comparison-enrolled", "0");
+    const { result } = renderHook(() =>
+      useSTTComparison({ storageKey: TEST_STORAGE_KEY })
+    );
+
+    let entry: STTComparisonEntry | null = null;
+    act(() => {
+      entry = result.current.recordComparison(
+        { transcript: "hello", confidence: 0.9 },
+        { transcript: "hello", confidence: 0.85 }
+      );
+    });
+
+    expect(entry).toBeNull();
+  });
+
+  it("recordComparison persists entry and returns it when enrolled", () => {
+    sessionStorage.setItem("stt-comparison-enrolled", "1");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { result } = renderHook(() =>
+      useSTTComparison({ storageKey: TEST_STORAGE_KEY, samplingRate: 100 })
+    );
+
+    let entry: STTComparisonEntry | null = null;
+    act(() => {
+      entry = result.current.recordComparison(
+        { transcript: "where is the library", confidence: 0.92 },
+        { transcript: "where is the library", confidence: 0.88 }
+      );
+    });
+
+    expect(entry).not.toBeNull();
+    expect(entry!.browserTranscript).toBe("where is the library");
+    expect(entry!.googleTranscript).toBe("where is the library");
+    expect(entry!.browserConfidence).toBe(0.92);
+    expect(entry!.googleConfidence).toBe(0.88);
+    expect(entry!.matchRate).toBe(1);
+    expect(entry!.wer).toBe(0);
+    expect(entry!.sessionId).toBeTruthy();
+    expect(entry!.utteranceId).toBeTruthy();
+
+    const stored = JSON.parse(localStorage.getItem(TEST_STORAGE_KEY) ?? "[]");
+    expect(stored).toHaveLength(1);
+
+    expect(consoleSpy).toHaveBeenCalledWith("[STT A/B]", expect.objectContaining({ browserTranscript: "where is the library" }));
+    consoleSpy.mockRestore();
+  });
+
+  it("recordComparison calculates WER for different transcripts", () => {
+    sessionStorage.setItem("stt-comparison-enrolled", "1");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { result } = renderHook(() =>
+      useSTTComparison({ storageKey: TEST_STORAGE_KEY, samplingRate: 100 })
+    );
+
+    let entry: STTComparisonEntry | null = null;
+    act(() => {
+      entry = result.current.recordComparison(
+        { transcript: "hello world", confidence: 0.9 },
+        { transcript: "hello earth", confidence: 0.8 }
+      );
+    });
+
+    expect(entry!.wer).toBe(0.5);
+    expect(entry!.matchRate).toBe(0.5);
+
+    vi.restoreAllMocks();
+  });
+
+  it("increments utteranceId across multiple recordings", () => {
+    sessionStorage.setItem("stt-comparison-enrolled", "1");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { result } = renderHook(() =>
+      useSTTComparison({ storageKey: TEST_STORAGE_KEY, samplingRate: 100 })
+    );
+
+    const entries: (STTComparisonEntry | null)[] = [];
+    act(() => {
+      entries.push(
+        result.current.recordComparison(
+          { transcript: "first", confidence: 0.9 },
+          { transcript: "first", confidence: 0.8 }
+        )
+      );
+      entries.push(
+        result.current.recordComparison(
+          { transcript: "second", confidence: 0.9 },
+          { transcript: "second", confidence: 0.8 }
+        )
+      );
+    });
+
+    expect(entries[0]!.utteranceId).toContain("-1");
+    expect(entries[1]!.utteranceId).toContain("-2");
+
+    vi.restoreAllMocks();
+  });
+
+  it("getStats returns stats from stored entries", () => {
+    sessionStorage.setItem("stt-comparison-enrolled", "1");
+
+    seedEntries([
+      makeEntry({ matchRate: 0.8, wer: 0.2 }),
+      makeEntry({ matchRate: 0.6, wer: 0.4 }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useSTTComparison({ storageKey: TEST_STORAGE_KEY, samplingRate: 100 })
+    );
+
+    let stats: ReturnType<typeof result.current.getStats>;
+    act(() => {
+      stats = result.current.getStats();
+    });
+
+    expect(stats!.totalComparisons).toBe(2);
+    expect(stats!.averageMatchRate).toBe(0.7);
+    expect(stats!.averageWER).toBeCloseTo(0.3);
+  });
+
+  it("clearLog removes all stored entries", () => {
+    sessionStorage.setItem("stt-comparison-enrolled", "1");
+    seedEntries([makeEntry()]);
+
+    const { result } = renderHook(() =>
+      useSTTComparison({ storageKey: TEST_STORAGE_KEY, samplingRate: 100 })
+    );
+
+    act(() => {
+      result.current.clearLog();
+    });
+
+    const stored = localStorage.getItem(TEST_STORAGE_KEY);
+    expect(JSON.parse(stored ?? "[]")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `useSTTComparison` hook (`src/hooks/useSTTComparison.ts`) that provides A/B testing infrastructure for comparing browser Web Speech API vs Google Cloud STT
- Configurable session sampling rate (default 10%) with session-sticky enrollment via sessionStorage
- Records comparison metrics (transcripts, confidence scores, WER, match rate) to localStorage with console logging for dev observability
- Includes `getComparisonStats()` for aggregated analysis (averages, win counts) and `clearLog()` for cleanup
- Pure utility functions (`calculateWER`, `calculateMatchRate`, `tokenize`) exported for reuse
- 33 tests covering all pure functions, enrollment logic, hook behavior, and edge cases