### PR TITLE
feat(2b): language/accent selector for STT

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -3,7 +3,10 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { ArrowUp } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useAppStore } from "@/store/app-store";
+import { getSttLang } from "@/lib/voice/speech-recognition";
 import VoiceButton from "./VoiceButton";
+import LanguageSelector from "./LanguageSelector";
 
 interface ChatInputProps {
   onSend: (message: string) => void;
@@ -75,6 +78,8 @@ export default function ChatInput({ onSend, isLoading }: ChatInputProps) {
   };
 
   const canSend = value.trim().length > 0 && !isLoading;
+  const sttLanguage = useAppStore((s) => s.sttLanguage);
+  const sttLang = getSttLang(sttLanguage);
 
   return (
     <form
@@ -85,7 +90,10 @@ export default function ChatInput({ onSend, isLoading }: ChatInputProps) {
         "transition-colors duration-200"
       )}
     >
-      <VoiceButton onTranscript={handleVoiceTranscript} />
+      <div className="flex items-end gap-1.5">
+        <VoiceButton onTranscript={handleVoiceTranscript} lang={sttLang} />
+        <LanguageSelector />
+      </div>
 
       <div className="relative flex-1 min-w-0">
         <textarea

--- a/src/components/chat/LanguageSelector.tsx
+++ b/src/components/chat/LanguageSelector.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Languages } from "lucide-react";
+import { useAppStore } from "@/store/app-store";
+import type { SttLanguage } from "@/types";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const STT_OPTIONS: { value: SttLanguage; label: string }[] = [
+  { value: "english", label: "English" },
+  { value: "singlish", label: "Singlish" },
+  { value: "mandarin-mix", label: "中英 Mix" },
+];
+
+export default function LanguageSelector() {
+  const sttLanguage = useAppStore((s) => s.sttLanguage);
+  const setSttLanguage = useAppStore((s) => s.setSttLanguage);
+
+  return (
+    <Select
+      value={sttLanguage}
+      onValueChange={(v) => setSttLanguage(v as SttLanguage)}
+    >
+      <SelectTrigger
+        size="sm"
+        className="h-8 gap-1 rounded-full border-border/40 bg-secondary/50 px-2 text-xs text-muted-foreground hover:bg-secondary"
+        aria-label="Speech language"
+      >
+        <Languages size={14} className="shrink-0" />
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent side="top" sideOffset={8} alignItemWithTrigger={false}>
+        {STT_OPTIONS.map((opt) => (
+          <SelectItem key={opt.value} value={opt.value}>
+            {opt.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/chat/VoiceButton.tsx
+++ b/src/components/chat/VoiceButton.tsx
@@ -7,9 +7,10 @@ import { cn } from "@/lib/utils";
 
 interface VoiceButtonProps {
   onTranscript: (text: string) => void;
+  lang?: string;
 }
 
-export default function VoiceButton({ onTranscript }: VoiceButtonProps) {
+export default function VoiceButton({ onTranscript, lang }: VoiceButtonProps) {
   const { isListening, startListening, stopListening } = useSpeechRecognition();
 
   const handleClick = () => {
@@ -17,7 +18,7 @@ export default function VoiceButton({ onTranscript }: VoiceButtonProps) {
     if (isListening) {
       stopListening();
     } else {
-      startListening(onTranscript, (msg) => toast.error(msg));
+      startListening(onTranscript, (msg) => toast.error(msg), lang);
     }
   };
 

--- a/src/lib/voice/speech-recognition.ts
+++ b/src/lib/voice/speech-recognition.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef } from "react";
+import type { SttLanguage } from "@/types";
 
 interface SpeechRecognitionEvent {
   results: SpeechRecognitionResultList;
@@ -24,18 +25,33 @@ declare global {
   }
 }
 
+/** BCP-47 language tag for each STT mode. */
+const STT_LANG_MAP: Record<SttLanguage, string> = {
+  english: "en-US",
+  singlish: "en-SG",
+  "mandarin-mix": "zh",
+};
+
+export function getSttLang(mode: SttLanguage): string {
+  return STT_LANG_MAP[mode];
+}
+
 export function useSpeechRecognition() {
   const [isListening, setIsListening] = useState(false);
   const [transcript, setTranscript] = useState("");
   const recognitionRef = useRef<ReturnType<typeof createRecognition> | null>(null);
 
   const startListening = useCallback(
-    (onResult: (text: string) => void, onError?: (message: string) => void) => {
+    (
+      onResult: (text: string) => void,
+      onError?: (message: string) => void,
+      lang: string = "en-SG",
+    ) => {
       const recognition = createRecognition();
       if (!recognition) return;
 
       recognitionRef.current = recognition;
-      recognition.lang = "en-SG";
+      recognition.lang = lang;
       recognition.interimResults = false;
       recognition.continuous = false;
 

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -3,7 +3,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { StateCreator } from "zustand";
-import type { POI, RouteInfo, CampusEvent, ChatMessage, DateRangePreset } from "@/types";
+import type { POI, RouteInfo, CampusEvent, ChatMessage, DateRangePreset, SttLanguage } from "@/types";
 
 type SheetContentMode = "default" | "poi-detail" | "event-detail";
 type MobileSheetState = "collapsed" | "peek" | "expanded";
@@ -47,6 +47,8 @@ export interface AppState {
   setIsSpeaking: (speaking: boolean) => void;
   ttsEnabled: boolean;
   setTtsEnabled: (enabled: boolean) => void;
+  sttLanguage: SttLanguage;
+  setSttLanguage: (lang: SttLanguage) => void;
 
   onboardingDismissed: boolean;
   setOnboardingDismissed: (dismissed: boolean) => void;
@@ -119,6 +121,8 @@ type ChatSlice = Pick<
   | "setIsSpeaking"
   | "ttsEnabled"
   | "setTtsEnabled"
+  | "sttLanguage"
+  | "setSttLanguage"
 >;
 
 function generateId(): string {
@@ -185,6 +189,8 @@ const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (set) => ({
   setIsSpeaking: (speaking) => set({ isSpeaking: speaking }),
   ttsEnabled: false,
   setTtsEnabled: (enabled) => set({ ttsEnabled: enabled }),
+  sttLanguage: "english",
+  setSttLanguage: (lang) => set({ sttLanguage: lang }),
   chatMessages: [],
   setChatMessages: (messages) => set({ chatMessages: messages }),
   conversationId: generateId(),
@@ -217,6 +223,7 @@ export const useAppStore = create<AppState>()(
       name: "asksussi-prefs",
       partialize: (state) => ({
         ttsEnabled: state.ttsEnabled,
+        sttLanguage: state.sttLanguage,
         activePanel: state.activePanel,
         onboardingDismissed: state.onboardingDismissed,
         introDismissed: state.introDismissed,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,3 +62,5 @@ export interface ChatMessage {
 }
 
 export type DateRangePreset = "all" | "1d" | "3d" | "7d";
+
+export type SttLanguage = "english" | "singlish" | "mandarin-mix";

--- a/tests/components/chat/ChatInput.test.tsx
+++ b/tests/components/chat/ChatInput.test.tsx
@@ -5,6 +5,26 @@ vi.mock("@/components/chat/VoiceButton", () => ({
   default: () => <button type="button" aria-label="Mock voice" />,
 }));
 
+vi.mock("@/components/chat/LanguageSelector", () => ({
+  default: () => <div data-testid="lang-selector" />,
+}));
+
+vi.mock("@/store/app-store", () => ({
+  useAppStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ sttLanguage: "english" }),
+}));
+
+vi.mock("@/lib/voice/speech-recognition", () => ({
+  getSttLang: (mode: string) => {
+    const map: Record<string, string> = {
+      english: "en-US",
+      singlish: "en-SG",
+      "mandarin-mix": "zh",
+    };
+    return map[mode];
+  },
+}));
+
 import ChatInput from "@/components/chat/ChatInput";
 
 describe("ChatInput", () => {

--- a/tests/components/chat/LanguageSelector.test.tsx
+++ b/tests/components/chat/LanguageSelector.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const mockSetSttLanguage = vi.fn();
+let mockSttLanguage = "english";
+
+vi.mock("@/store/app-store", () => ({
+  useAppStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      sttLanguage: mockSttLanguage,
+      setSttLanguage: mockSetSttLanguage,
+    }),
+}));
+
+import LanguageSelector from "@/components/chat/LanguageSelector";
+
+describe("LanguageSelector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSttLanguage = "english";
+  });
+
+  it("renders a trigger with speech language aria-label", () => {
+    render(<LanguageSelector />);
+
+    expect(screen.getByLabelText("Speech language")).toBeInTheDocument();
+  });
+
+  it("renders a combobox role trigger", () => {
+    render(<LanguageSelector />);
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("has the selected value in the hidden input for english", () => {
+    render(<LanguageSelector />);
+
+    const hiddenInput = document.querySelector("input[aria-hidden='true']");
+    expect(hiddenInput).toHaveValue("english");
+  });
+
+  it("has the selected value in the hidden input for singlish", () => {
+    mockSttLanguage = "singlish";
+    render(<LanguageSelector />);
+
+    const hiddenInput = document.querySelector("input[aria-hidden='true']");
+    expect(hiddenInput).toHaveValue("singlish");
+  });
+
+  it("has the selected value in the hidden input for mandarin-mix", () => {
+    mockSttLanguage = "mandarin-mix";
+    render(<LanguageSelector />);
+
+    const hiddenInput = document.querySelector("input[aria-hidden='true']");
+    expect(hiddenInput).toHaveValue("mandarin-mix");
+  });
+});

--- a/tests/components/chat/VoiceButton.test.tsx
+++ b/tests/components/chat/VoiceButton.test.tsx
@@ -99,6 +99,20 @@ describe("VoiceButton", () => {
     expect(mockStartListening).toHaveBeenCalledWith(
       onTranscript,
       expect.any(Function),
+      undefined,
+    );
+  });
+
+  it("passes lang to startListening when provided", () => {
+    const onTranscript = vi.fn();
+    render(<VoiceButton onTranscript={onTranscript} lang="en-SG" />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(mockStartListening).toHaveBeenCalledWith(
+      onTranscript,
+      expect.any(Function),
+      "en-SG",
     );
   });
 

--- a/tests/lib/voice/speech-recognition.test.ts
+++ b/tests/lib/voice/speech-recognition.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { useSpeechRecognition } from "@/lib/voice/speech-recognition";
+import { useSpeechRecognition, getSttLang } from "@/lib/voice/speech-recognition";
 
 interface MockRecognitionInstance {
   lang: string;
@@ -61,6 +61,18 @@ describe("useSpeechRecognition", () => {
     expect(inst.lang).toBe("en-SG");
     expect(inst.interimResults).toBe(false);
     expect(inst.continuous).toBe(false);
+  });
+
+  it("uses the provided lang parameter", () => {
+    const { result } = renderHook(() => useSpeechRecognition());
+    const onResult = vi.fn();
+
+    act(() => {
+      result.current.startListening(onResult, undefined, "zh");
+    });
+
+    const inst = getInstance(MockSpeechRecognition);
+    expect(inst.lang).toBe("zh");
   });
 
   it("calls recognition.start() and sets isListening to true", () => {
@@ -196,5 +208,19 @@ describe("useSpeechRecognition", () => {
     });
 
     expect(result.current.isListening).toBe(false);
+  });
+});
+
+describe("getSttLang", () => {
+  it("returns en-US for english", () => {
+    expect(getSttLang("english")).toBe("en-US");
+  });
+
+  it("returns en-SG for singlish", () => {
+    expect(getSttLang("singlish")).toBe("en-SG");
+  });
+
+  it("returns zh for mandarin-mix", () => {
+    expect(getSttLang("mandarin-mix")).toBe("zh");
   });
 });

--- a/tests/store/app-store.test.ts
+++ b/tests/store/app-store.test.ts
@@ -43,6 +43,7 @@ function resetStore() {
     streetViewEvent: null,
     isSpeaking: false,
     ttsEnabled: false,
+    sttLanguage: "english",
     onboardingDismissed: false,
     chatMessages: [],
     pendingChatMessage: null,
@@ -70,6 +71,7 @@ describe("app-store", () => {
     expect(state.selectedEvent).toBeNull();
     expect(state.isSpeaking).toBe(false);
     expect(state.ttsEnabled).toBe(false);
+    expect(state.sttLanguage).toBe("english");
     expect(state.onboardingDismissed).toBe(false);
     expect(state.chatMessages).toEqual([]);
     expect(state.pendingChatMessage).toBeNull();
@@ -153,6 +155,15 @@ describe("app-store", () => {
     expect(useAppStore.getState().ttsEnabled).toBe(true);
     useAppStore.getState().setTtsEnabled(false);
     expect(useAppStore.getState().ttsEnabled).toBe(false);
+  });
+
+  it("setSttLanguage updates STT language", () => {
+    useAppStore.getState().setSttLanguage("singlish");
+    expect(useAppStore.getState().sttLanguage).toBe("singlish");
+    useAppStore.getState().setSttLanguage("mandarin-mix");
+    expect(useAppStore.getState().sttLanguage).toBe("mandarin-mix");
+    useAppStore.getState().setSttLanguage("english");
+    expect(useAppStore.getState().sttLanguage).toBe("english");
   });
 
   it("setOnboardingDismissed works", () => {


### PR DESCRIPTION
## Summary

- Adds a language/accent selector dropdown next to the microphone button in the chat input bar
- Three STT modes: **English** (`en-US`), **Singlish** (`en-SG`), and **中英 Mix** (`zh` for Mandarin-English code-switching)
- Selection persists in localStorage via the existing Zustand persist middleware

## Changes

### New files
- `src/components/chat/LanguageSelector.tsx` — Select dropdown using existing shadcn/base-ui Select primitive, positioned next to VoiceButton
- `tests/components/chat/LanguageSelector.test.tsx` — Tests for the new component

### Modified files
- `src/types/index.ts` — Added `SttLanguage` union type (`"english" | "singlish" | "mandarin-mix"`)
- `src/store/app-store.ts` — Added `sttLanguage` + `setSttLanguage` to ChatSlice, persisted to localStorage
- `src/lib/voice/speech-recognition.ts` — `startListening` now accepts an optional `lang` parameter (default `en-SG`); exported `getSttLang()` mapping function
- `src/components/chat/VoiceButton.tsx` — Accepts optional `lang` prop, passes it to `startListening`
- `src/components/chat/ChatInput.tsx` — Reads `sttLanguage` from store, renders `LanguageSelector` next to `VoiceButton`, passes resolved BCP-47 lang to `VoiceButton`

### Test updates
- Updated store, speech-recognition, VoiceButton, and ChatInput tests for new language parameter
- All 464 tests pass, lint clean