### PR TITLE
feat(5.2): health-aware navigation suggestions

### DIFF
--- a/src/components/navigation/HealthNavigationSuggestions.tsx
+++ b/src/components/navigation/HealthNavigationSuggestions.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import Link from "next/link";
+import {
+  Accessibility,
+  Pill,
+  Brain,
+  Stethoscope,
+  HeartHandshake,
+  Navigation,
+} from "lucide-react";
+import type { ComponentType } from "react";
+
+import { cn } from "@/lib/utils";
+
+export type HealthConcern =
+  | "mobility issues"
+  | "medication concerns"
+  | "cognitive decline"
+  | "general checkup"
+  | "caregiver stress";
+
+interface SuggestionConfig {
+  icon: ComponentType<{ size?: number; className?: string }>;
+  label: string;
+  destination: string;
+}
+
+export const HEALTH_SUGGESTIONS: Record<HealthConcern, SuggestionConfig> = {
+  "mobility issues": {
+    icon: Accessibility,
+    label: "Find physiotherapy clinic nearby",
+    destination: "physiotherapy",
+  },
+  "medication concerns": {
+    icon: Pill,
+    label: "Walk to nearest pharmacy",
+    destination: "pharmacy",
+  },
+  "cognitive decline": {
+    icon: Brain,
+    label: "Find memory clinic nearby",
+    destination: "memory-clinic",
+  },
+  "general checkup": {
+    icon: Stethoscope,
+    label: "Navigate to nearest polyclinic",
+    destination: "polyclinic",
+  },
+  "caregiver stress": {
+    icon: HeartHandshake,
+    label: "Find caregiver support centre nearby",
+    destination: "caregiver-support",
+  },
+};
+
+export interface HealthNavigationSuggestionsProps {
+  concerns: string[];
+  className?: string;
+}
+
+export default function HealthNavigationSuggestions({
+  concerns,
+  className,
+}: HealthNavigationSuggestionsProps) {
+  const matched = concerns.filter(
+    (c): c is HealthConcern => c in HEALTH_SUGGESTIONS,
+  );
+
+  if (matched.length === 0) return null;
+
+  return (
+    <section
+      aria-label="Health navigation suggestions"
+      className={cn("flex flex-col gap-2", className)}
+    >
+      <h3 className="text-sm font-semibold text-foreground px-1">
+        Suggested nearby places
+      </h3>
+      <ul className="flex flex-col gap-1.5">
+        {matched.map((concern) => {
+          const { icon: Icon, label, destination } =
+            HEALTH_SUGGESTIONS[concern];
+          return (
+            <li key={concern}>
+              <Link
+                href={`/navigation?destination=${encodeURIComponent(destination)}`}
+                aria-label={`${label} — navigate to ${destination.replace(/-/g, " ")}`}
+                className={cn(
+                  "flex items-center gap-3 rounded-lg px-3 py-2.5",
+                  "bg-card ring-1 ring-foreground/10",
+                  "hover:bg-accent/50 active:bg-accent",
+                  "transition-colors group",
+                )}
+              >
+                <span
+                  className="flex-shrink-0 flex items-center justify-center w-8 h-8 rounded-full bg-primary/10"
+                  aria-hidden="true"
+                >
+                  <Icon size={16} className="text-primary" />
+                </span>
+                <span className="flex-1 text-sm font-medium text-foreground group-hover:text-primary transition-colors">
+                  {label}
+                </span>
+                <span
+                  className="flex-shrink-0 inline-flex items-center gap-1 rounded-full bg-primary px-3 py-1 text-xs font-medium text-primary-foreground"
+                  aria-hidden="true"
+                >
+                  <Navigation size={12} aria-hidden="true" />
+                  Navigate
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/tests/components/navigation/HealthNavigationSuggestions.test.tsx
+++ b/tests/components/navigation/HealthNavigationSuggestions.test.tsx
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import HealthNavigationSuggestions, {
+  HEALTH_SUGGESTIONS,
+  type HealthConcern,
+} from "@/components/navigation/HealthNavigationSuggestions";
+
+describe("HealthNavigationSuggestions", () => {
+  const allConcerns: HealthConcern[] = [
+    "mobility issues",
+    "medication concerns",
+    "cognitive decline",
+    "general checkup",
+    "caregiver stress",
+  ];
+
+  it("renders nothing when concerns array is empty", () => {
+    const { container } = render(
+      <HealthNavigationSuggestions concerns={[]} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when no concerns match known health concerns", () => {
+    const { container } = render(
+      <HealthNavigationSuggestions concerns={["unknown issue", "random"]} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a suggestion for each matched concern", () => {
+    render(<HealthNavigationSuggestions concerns={allConcerns} />);
+
+    for (const concern of allConcerns) {
+      const { label } = HEALTH_SUGGESTIONS[concern];
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it("renders correct labels for each health concern", () => {
+    render(<HealthNavigationSuggestions concerns={allConcerns} />);
+
+    expect(
+      screen.getByText("Find physiotherapy clinic nearby"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Walk to nearest pharmacy"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Find memory clinic nearby"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Navigate to nearest polyclinic"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Find caregiver support centre nearby"),
+    ).toBeInTheDocument();
+  });
+
+  it("links each suggestion to /navigation?destination=TYPE", () => {
+    render(<HealthNavigationSuggestions concerns={allConcerns} />);
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(5);
+
+    const expectedDestinations = [
+      "physiotherapy",
+      "pharmacy",
+      "memory-clinic",
+      "polyclinic",
+      "caregiver-support",
+    ];
+
+    links.forEach((link, i) => {
+      expect(link).toHaveAttribute(
+        "href",
+        `/navigation?destination=${expectedDestinations[i]}`,
+      );
+    });
+  });
+
+  it("renders only matched concerns and ignores unknown ones", () => {
+    render(
+      <HealthNavigationSuggestions
+        concerns={["mobility issues", "unknown", "caregiver stress"]}
+      />,
+    );
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(2);
+
+    expect(
+      screen.getByText("Find physiotherapy clinic nearby"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Find caregiver support centre nearby"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a Navigate button for each suggestion", () => {
+    render(
+      <HealthNavigationSuggestions concerns={["general checkup"]} />,
+    );
+
+    expect(screen.getByText("Navigate")).toBeInTheDocument();
+  });
+
+  it("renders the section heading", () => {
+    render(
+      <HealthNavigationSuggestions concerns={["mobility issues"]} />,
+    );
+
+    expect(screen.getByText("Suggested nearby places")).toBeInTheDocument();
+  });
+
+  it("has accessible section labelling", () => {
+    render(
+      <HealthNavigationSuggestions concerns={["mobility issues"]} />,
+    );
+
+    expect(
+      screen.getByRole("region", { name: "Health navigation suggestions" }),
+    ).toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    render(
+      <HealthNavigationSuggestions
+        concerns={["mobility issues"]}
+        className="mt-4"
+      />,
+    );
+
+    const section = screen.getByRole("region");
+    expect(section.className).toContain("mt-4");
+  });
+
+  it("renders a single suggestion correctly", () => {
+    render(
+      <HealthNavigationSuggestions concerns={["medication concerns"]} />,
+    );
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute(
+      "href",
+      "/navigation?destination=pharmacy",
+    );
+    expect(
+      screen.getByText("Walk to nearest pharmacy"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("HEALTH_SUGGESTIONS", () => {
+  it("maps all five health concerns", () => {
+    expect(Object.keys(HEALTH_SUGGESTIONS)).toHaveLength(5);
+  });
+
+  it("each suggestion has icon, label, and destination", () => {
+    for (const config of Object.values(HEALTH_SUGGESTIONS)) {
+      expect(config).toHaveProperty("icon");
+      expect(config).toHaveProperty("label");
+      expect(config).toHaveProperty("destination");
+      expect(typeof config.label).toBe("string");
+      expect(typeof config.destination).toBe("string");
+      expect(config.label.length).toBeGreaterThan(0);
+      expect(config.destination.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `HealthNavigationSuggestions` component that maps health concerns to nearby place suggestions with navigation links
- Supports 5 health concern types: mobility issues → physiotherapy, medication concerns → pharmacy, cognitive decline → memory clinic, general checkup → polyclinic, caregiver stress → caregiver support centre
- Each suggestion renders an icon (Lucide), descriptive label, and a "Navigate" button linking to `/navigation?destination=TYPE`
- Component is reusable — accepts `concerns: string[]` and filters to known concerns, returns `null` when none match
- Full test coverage with 12 tests covering rendering, routing, accessibility, and edge cases
- Lint clean, all 642 tests pass