### PR TITLE
feat: add Call This Centre button to AAC cards

### DIFF
--- a/src/components/aac/AACResultCard.tsx
+++ b/src/components/aac/AACResultCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { POI } from "@/types";
-import { MapPin, Footprints, Loader2 } from "lucide-react";
+import { MapPin, Footprints, Loader2, Phone } from "lucide-react";
 import { useWalkingRoute } from "@/hooks/useWalkingRoute";
 
 interface AACResultCardProps {
@@ -19,54 +19,66 @@ export default function AACResultCard({ poi, distanceKm, onSelect }: AACResultCa
   const { walkTo, isLoading: isWalking } = useWalkingRoute();
 
   return (
-    <button
-      type="button"
-      aria-label={`Select ${poi.name}`}
-      onClick={() => onSelect(poi)}
-      className="w-full text-left px-3 py-2.5 rounded-lg border border-border bg-card hover:bg-accent/50 active:bg-accent transition-colors cursor-pointer group relative"
-    >
-      <div className="flex items-start gap-2.5">
-        <div className="mt-0.5 flex-shrink-0 w-7 h-7 rounded-full bg-poi-aac/15 flex items-center justify-center">
-          <MapPin size={14} className="text-poi-aac" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <p className="text-sm font-medium leading-snug text-foreground group-hover:text-primary transition-colors truncate pr-8">
-            {poi.name}
-          </p>
-          {poi.address && (
-            <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
-              {poi.address}
-            </p>
-          )}
-          {poi.hours && (
-            <p className="text-xs text-muted-foreground/70 mt-0.5">
-              {poi.hours}
-            </p>
-          )}
-        </div>
-        {distanceKm !== null && (
-          <span className="flex-shrink-0 text-xs font-medium text-muted-foreground tabular-nums mt-0.5">
-            {formatDistance(distanceKm)}
-          </span>
-        )}
-      </div>
+    <div className="rounded-lg border border-border bg-card overflow-hidden">
       <button
         type="button"
-        aria-label={`Walk to ${poi.name}`}
-        disabled={isWalking}
-        onClick={(e) => {
-          e.stopPropagation();
-          walkTo(poi);
-        }}
-        className="absolute top-2 right-2 flex items-center justify-center w-7 h-7 rounded-full bg-primary/10 hover:bg-primary/20 active:scale-90 transition-all disabled:opacity-60"
+        aria-label={`Select ${poi.name}`}
+        onClick={() => onSelect(poi)}
+        className="w-full text-left px-3 py-2.5 hover:bg-accent/50 active:bg-accent transition-colors cursor-pointer group relative"
       >
-        {isWalking ? (
-          <Loader2 size={14} className="animate-spin text-primary" aria-hidden="true" />
-        ) : (
-          <Footprints size={14} className="text-primary" aria-hidden="true" />
-        )}
+        <div className="flex items-start gap-2.5">
+          <div className="mt-0.5 flex-shrink-0 w-7 h-7 rounded-full bg-poi-aac/15 flex items-center justify-center">
+            <MapPin size={14} className="text-poi-aac" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium leading-snug text-foreground group-hover:text-primary transition-colors truncate pr-8">
+              {poi.name}
+            </p>
+            {poi.address && (
+              <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                {poi.address}
+              </p>
+            )}
+            {poi.hours && (
+              <p className="text-xs text-muted-foreground/70 mt-0.5">
+                {poi.hours}
+              </p>
+            )}
+          </div>
+          {distanceKm !== null && (
+            <span className="flex-shrink-0 text-xs font-medium text-muted-foreground tabular-nums mt-0.5">
+              {formatDistance(distanceKm)}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          aria-label={`Walk to ${poi.name}`}
+          disabled={isWalking}
+          onClick={(e) => {
+            e.stopPropagation();
+            walkTo(poi);
+          }}
+          className="absolute top-2 right-2 flex items-center justify-center w-7 h-7 rounded-full bg-primary/10 hover:bg-primary/20 active:scale-90 transition-all disabled:opacity-60"
+        >
+          {isWalking ? (
+            <Loader2 size={14} className="animate-spin text-primary" aria-hidden="true" />
+          ) : (
+            <Footprints size={14} className="text-primary" aria-hidden="true" />
+          )}
+        </button>
       </button>
-    </button>
+      {poi.contact && (
+        <a
+          href={`tel:${poi.contact.replace(/\s/g, "")}`}
+          aria-label={`Call ${poi.name}`}
+          className="flex items-center justify-center gap-2.5 w-full h-14 bg-green-600 hover:bg-green-700 active:bg-green-800 text-white font-semibold text-base transition-colors"
+        >
+          <Phone size={22} aria-hidden="true" />
+          📞 Call This Centre
+        </a>
+      )}
+    </div>
   );
 }
 

--- a/src/components/ui/POICard.tsx
+++ b/src/components/ui/POICard.tsx
@@ -164,27 +164,40 @@ export default function POICard({ poi }: POICardProps) {
               </div>
             )}
 
-            <div className="flex items-center gap-2 pt-3 border-t border-border">
-              <button
-                type="button"
-                onClick={handleShowOnMap}
-                className="flex-1 bg-surface-brand text-surface-brand-foreground rounded-xl px-4 py-3 min-h-[44px] text-[0.9375rem] font-semibold hover:bg-surface-brand/90 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
-              >
-                <Navigation size={16} aria-hidden="true" />
-                Show on map
-              </button>
-              {poi.website && (
+            <div className="flex flex-col gap-2 pt-3 border-t border-border">
+              {isAAC && poi.contact && (
                 <a
-                  href={poi.website}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  href={`tel:${poi.contact.replace(/\s/g, "")}`}
+                  aria-label={`Call ${poi.name}`}
                   onClick={(e) => e.stopPropagation()}
-                  className="inline-flex items-center gap-1.5 rounded-xl border border-border px-4 py-3 min-h-[44px] text-[0.9375rem] font-semibold text-card-foreground hover:bg-muted active:scale-[0.98] transition-all"
+                  className="flex items-center justify-center gap-2.5 w-full h-14 rounded-xl bg-green-600 hover:bg-green-700 active:bg-green-800 text-white font-semibold text-base transition-colors active:scale-[0.98]"
                 >
-                  <ExternalLink size={16} aria-hidden="true" />
-                  Website
+                  <Phone size={22} aria-hidden="true" />
+                  📞 Call This Centre
                 </a>
               )}
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleShowOnMap}
+                  className="flex-1 bg-surface-brand text-surface-brand-foreground rounded-xl px-4 py-3 min-h-[44px] text-[0.9375rem] font-semibold hover:bg-surface-brand/90 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+                >
+                  <Navigation size={16} aria-hidden="true" />
+                  Show on map
+                </button>
+                {poi.website && (
+                  <a
+                    href={poi.website}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    className="inline-flex items-center gap-1.5 rounded-xl border border-border px-4 py-3 min-h-[44px] text-[0.9375rem] font-semibold text-card-foreground hover:bg-muted active:scale-[0.98] transition-all"
+                  >
+                    <ExternalLink size={16} aria-hidden="true" />
+                    Website
+                  </a>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/src/lib/maps/active-ageing-centres.ts
+++ b/src/lib/maps/active-ageing-centres.ts
@@ -11,6 +11,7 @@ export const ACTIVE_AGEING_CENTRES: POI[] = [
       "Operated by Allkin. Programs include exercises, social activities, befriending, digital literacy workshops and community support for seniors aged 60+.",
     address: "Blk 604 Yishun St 61 #01-328, Singapore 760604",
     hours: "Mon–Fri 9AM–5PM",
+    contact: "+65 6757 4495",
   },
   {
     id: "aac-amkfsc-ang-mo-kio-226d",
@@ -22,6 +23,7 @@ export const ACTIVE_AGEING_CENTRES: POI[] = [
       "Operated by AMKFSC Community Services. Programs include exercise sessions, social activities, health monitoring, befriending and community support for seniors aged 60+.",
     address: "Blk 226D Ang Mo Kio Ave 1 #01-02, Singapore 564226",
     hours: "Mon–Fri 9AM–5PM",
+    contact: "+65 6453 6899",
   },
   {
     id: "aac-amkfsc-ang-mo-kio-645",
@@ -33,6 +35,7 @@ export const ACTIVE_AGEING_CENTRES: POI[] = [
       "Operated by AMKFSC Community Services. Programs include Tai Chi and strength training, social activities, befriending and outreach support for seniors aged 60+.",
     address: "Blk 645 Ang Mo Kio Ave 6 #01-4802, Singapore 560645",
     hours: "Mon–Fri 9AM–5PM",
+    contact: "+65 6453 2495",
   },
   {
     id: "aac-amkfsc-cheng-san",
@@ -44,6 +47,7 @@ export const ACTIVE_AGEING_CENTRES: POI[] = [
       "Operated by AMKFSC Community Services. Programs include exercise classes, art and craft, health screening and community support for seniors aged 60+.",
     address: "Blk 528 Ang Mo Kio Ave 10 #01-2439, Singapore 560528",
     hours: "Mon–Fri 9AM–5PM",
+    contact: "+65 6459 8887",
   },
   {
     id: "aac-amkfsc-kebun-baru",
@@ -55,6 +59,7 @@ export const ACTIVE_AGEING_CENTRES: POI[] = [
       "Operated by AMKFSC Community Services. Programs include exercise programmes, social activities, digital literacy and buddying support for seniors aged 60+.",
     address: "Blk 165 Ang Mo Kio Ave 4 #01-454, Singapore 560165",
     hours: "Mon–Fri 9AM–5PM",
+    contact: "+65 6456 1601",
   },
   {
     id: "aac-amkfsc-sengkang",


### PR DESCRIPTION
## Summary
- Added a prominent **📞 Call This Centre** button to AAC cards (both `AACResultCard` in the search panel and `POICard` in the detail view)
- Button uses `tel:` link for direct phone call, 56px height, full width, green background with phone icon
- Button only appears when `poi.contact` is available — hidden otherwise
- Added sample phone numbers to 5 AACs in `active-ageing-centres.ts` (the older data file that was missing contact info)

## Changes
| File | Change |
|------|--------|
| `src/components/aac/AACResultCard.tsx` | Restructured to wrap card in `<div>`, added full-width call `<a>` with `tel:` href below card content |
| `src/components/ui/POICard.tsx` | Added call button above the "Show on map" / "Website" action row for AAC POIs with contact |
| `src/lib/maps/active-ageing-centres.ts` | Added `contact` field to first 5 AAC entries as examples |

## Testing
- `npm run lint` — clean
- `npm test` — 810/810 tests pass