### PR TITLE
feat: SOS emergency button with location sharing

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -28,6 +28,7 @@ import AerialViewButton from "@/components/map/AerialViewButton";
 import POIPopup, { POIDetailCard } from "@/components/map/POIPopup";
 import EventPopup, { EventDetailCard } from "@/components/map/EventPopup";
 import Onboarding from "@/components/layout/Onboarding";
+import SOSButton from "@/components/senior/SOSButton";
 import { MobileSheet, type SnapName } from "@/components/layout/MobileSheet";
 import { createStreetViewEventFromPOI } from "@/lib/maps/poi-utils";
 
@@ -445,6 +446,7 @@ export default function AppShell() {
       </APIProvider>
 
       <Onboarding />
+      <SOSButton />
     </div>
   );
 }

--- a/src/components/senior/SOSButton.tsx
+++ b/src/components/senior/SOSButton.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+
+type SOSView = "closed" | "menu" | "locating";
+
+const EMERGENCY_NUMBER = "995";
+
+function reverseGeocode(
+  lat: number,
+  lng: number,
+): Promise<string> {
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+  if (!apiKey) return Promise.resolve(`${lat.toFixed(5)}, ${lng.toFixed(5)}`);
+
+  return fetch(
+    `https://maps.googleapis.com/maps/api/geocode/json?latlng=${lat},${lng}&key=${apiKey}`,
+  )
+    .then((res) => res.json())
+    .then((data: { results?: Array<{ formatted_address: string }> }) => {
+      const addr = data.results?.[0]?.formatted_address;
+      return addr ?? `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
+    })
+    .catch(() => `${lat.toFixed(5)}, ${lng.toFixed(5)}`);
+}
+
+function mapsLink(lat: number, lng: number): string {
+  return `https://maps.google.com/?q=${lat},${lng}`;
+}
+
+export default function SOSButton() {
+  const [view, setView] = useState<SOSView>("closed");
+  const [lat, setLat] = useState<number | null>(null);
+  const [lng, setLng] = useState<number | null>(null);
+  const [address, setAddress] = useState<string | null>(null);
+  const [geoError, setGeoError] = useState<string | null>(null);
+  const [locating, setLocating] = useState(false);
+
+  const requestLocation = useCallback(() => {
+    if (!navigator.geolocation) {
+      setGeoError("Geolocation is not supported by this browser.");
+      return;
+    }
+
+    setLocating(true);
+    setGeoError(null);
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const newLat = position.coords.latitude;
+        const newLng = position.coords.longitude;
+        setLat(newLat);
+        setLng(newLng);
+        setLocating(false);
+
+        reverseGeocode(newLat, newLng).then(setAddress);
+      },
+      (err) => {
+        setLocating(false);
+        if (err.code === err.PERMISSION_DENIED) {
+          setGeoError("Location access denied. Please enable it in settings.");
+        } else {
+          setGeoError("Unable to get location. Please try again.");
+        }
+      },
+      { enableHighAccuracy: true, timeout: 15000, maximumAge: 30000 },
+    );
+  }, []);
+
+  const handleOpen = useCallback(() => {
+    setView("menu");
+    setLat(null);
+    setLng(null);
+    setAddress(null);
+    setGeoError(null);
+    requestLocation();
+  }, [requestLocation]);
+
+  const handleClose = useCallback(() => {
+    setView("closed");
+  }, []);
+
+  const handleShareLocation = useCallback(() => {
+    if (lat === null || lng === null) return;
+
+    const link = mapsLink(lat, lng);
+    const message = `I need help. My location: ${link}`;
+
+    if (navigator.share) {
+      navigator.share({ title: "SOS - My Location", text: message }).catch(() => undefined);
+    } else {
+      window.open(`sms:?body=${encodeURIComponent(message)}`, "_self");
+    }
+  }, [lat, lng]);
+
+  useEffect(() => {
+    if (view === "closed") return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setView("closed");
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [view]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        className="fixed bottom-6 right-6 z-50 flex items-center justify-center w-16 h-16 rounded-full bg-red-600 hover:bg-red-700 active:bg-red-800 shadow-lg shadow-red-600/30 transition-colors"
+        aria-label="SOS Emergency"
+      >
+        <span className="text-white font-extrabold text-lg select-none">
+          SOS
+        </span>
+      </button>
+
+      {view !== "closed" && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="SOS Emergency options"
+        >
+          <div className="w-full max-w-sm rounded-2xl bg-white dark:bg-neutral-900 shadow-2xl p-6 flex flex-col gap-4">
+            <h2 className="text-xl font-bold text-center text-red-600">
+              Emergency Help
+            </h2>
+
+            <a
+              href={`tel:${EMERGENCY_NUMBER}`}
+              className="flex items-center justify-center gap-2 w-full py-4 rounded-xl bg-red-600 hover:bg-red-700 active:bg-red-800 text-white text-lg font-bold transition-colors"
+            >
+              <span aria-hidden="true">📞</span>
+              Call Emergency ({EMERGENCY_NUMBER})
+            </a>
+
+            <button
+              type="button"
+              onClick={handleShareLocation}
+              disabled={lat === null || lng === null}
+              className="flex items-center justify-center gap-2 w-full py-4 rounded-xl bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white text-lg font-bold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <span aria-hidden="true">📱</span>
+              Share My Location with Family
+            </button>
+
+            <div className="w-full rounded-xl bg-neutral-100 dark:bg-neutral-800 p-4 text-center min-h-[60px] flex items-center justify-center">
+              {locating && (
+                <p className="text-neutral-500 dark:text-neutral-400 text-sm">
+                  📍 Getting your location...
+                </p>
+              )}
+              {!locating && geoError && (
+                <p className="text-red-500 text-sm">{geoError}</p>
+              )}
+              {!locating && !geoError && address && (
+                <p className="text-lg font-semibold text-neutral-900 dark:text-white">
+                  <span aria-hidden="true">📍</span> I Am Here: {address}
+                </p>
+              )}
+              {!locating && !geoError && !address && lat !== null && lng !== null && (
+                <p className="text-lg font-semibold text-neutral-900 dark:text-white">
+                  <span aria-hidden="true">📍</span> I Am Here: {lat.toFixed(5)}, {lng.toFixed(5)}
+                </p>
+              )}
+              {!locating && !geoError && !address && lat === null && (
+                <p className="text-neutral-500 dark:text-neutral-400 text-sm">
+                  📍 Waiting for location...
+                </p>
+              )}
+            </div>
+
+            <button
+              type="button"
+              onClick={handleClose}
+              className="w-full py-4 rounded-xl bg-neutral-200 dark:bg-neutral-700 hover:bg-neutral-300 dark:hover:bg-neutral-600 text-neutral-900 dark:text-white text-lg font-bold transition-colors"
+            >
+              ✕ Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/tests/components/senior/SOSButton.test.tsx
+++ b/tests/components/senior/SOSButton.test.tsx
@@ -1,0 +1,248 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import SOSButton from "@/components/senior/SOSButton";
+
+function mockGeolocation(overrides: Partial<Geolocation> = {}) {
+  const geo: Geolocation = {
+    getCurrentPosition: vi.fn(),
+    watchPosition: vi.fn(),
+    clearWatch: vi.fn(),
+    ...overrides,
+  };
+  Object.defineProperty(navigator, "geolocation", {
+    value: geo,
+    writable: true,
+    configurable: true,
+  });
+  return geo;
+}
+
+describe("SOSButton", () => {
+  beforeEach(() => {
+    mockGeolocation();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({ json: () => Promise.resolve({ results: [] }) }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the SOS trigger button", () => {
+    render(<SOSButton />);
+    const btn = screen.getByRole("button", { name: "SOS Emergency" });
+    expect(btn).toBeInTheDocument();
+    expect(screen.getByText("SOS")).toBeInTheDocument();
+  });
+
+  it("does not show modal initially", () => {
+    render(<SOSButton />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("opens modal on SOS button click", () => {
+    mockGeolocation({
+      getCurrentPosition: vi.fn(),
+    });
+    render(<SOSButton />);
+    fireEvent.click(screen.getByRole("button", { name: "SOS Emergency" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Emergency Help")).toBeInTheDocument();
+  });
+
+  it("shows call emergency link with tel:995", () => {
+    render(<SOSButton />);
+    fireEvent.click(screen.getByRole("button", { name: "SOS Emergency" }));
+    const callLink = screen.getByText(/Call Emergency/);
+    expect(callLink.closest("a")).toHaveAttribute("href", "tel:995");
+  });
+
+  it("shows share location button (disabled when no location)", () => {
+    render(<SOSButton />);
+    fireEvent.click(screen.getByRole("button", { name: "SOS Emergency" }));
+    const shareBtn = screen.getByRole("button", { name: /Share My Location/ });
+    expect(shareBtn).toBeDisabled();
+  });
+
+  it("enables share button after location is obtained", async () => {
+    mockGeolocation({
+      getCurrentPosition: vi.fn((success) => {
+        success({
+          coords: { latitude: 1.314, longitude: 103.765 },
+          timestamp: Date.now(),
+        } as GeolocationPosition);
+      }),
+    });
+
+    render(<SOSButton />);
+    fireEvent.click(screen.getByRole("button", { name: "SOS Emergency" }));
+
+    await waitFor(() => {
+      const shareBtn = screen.getByRole("button", { name: /Share My Location/ });
+      expect(shareBtn).not.toBeDisabled();
+    });
+  });
+
+  it("closes modal on Cancel button click", () => {
+    render(<SOSButton />);
+    fireEvent.click(screen.getByRole("button", { name: "SOS Emergency" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Cancel/ }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("closes modal on Escape key", () => {
+    render(<SOSButton />);
+    fireEvent.click(screen.getByRole("button", { name: "SOS Emergency" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("shows location error when geolocation is denied", async () => {
+    mockGeolocation({
+      getCurrentPosition: vi.fn((_success, error) => {
+        error!({
+          code: 1,
+          message: "User denied",
+          PERMISSION_DENIED: 1,
+          POSITION_UNAVAILABLE: 2,
+          TIMEOUT: 3,
+        } as GeolocationPositionError);
+      }),
+    });
+
+    render(<SOSButton />);
+    fireEvent.click(screen.getByRole("button", { name: "SOS Emergency" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Location access denied/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows address when reverse geocoding succeeds", async () => {
+    mockGeolocation({
+      getCurrentPosition: vi.fn((success) => {
+        success({
+          coords: { latitude: 1.314, longitude: 103.765 },
+          timestamp: Date.now(),
+        } as GeolocationPosition);
+      }),
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          json: () =>
+            Promise.resolve({
+              results: [{ formatted_address: "461 Clementi Rd, Singapore" }],
+            }),
+        }),
+      ),
+    );
+
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_MAPS_API_KEY", "test-key");
+
+    render(<SOSButton />);
+    fireEvent.click(screen.getByRole("button", { name: "SOS Emergency" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/461 Clementi Rd/)).toBeInTheDocument();
+    });
+  });
+
+  it("uses Web Share API when available", async () => {
+    const shareMock = vi.fn(() => Promise.resolve());
+    Object.defineProperty(navigator, "share", {
+      value: shareMock,
+      writable: true,
+      configurable: true,
+    });
+
+    mockGeolocation({
+      getCurrentPosition: vi.fn((success) => {
+        success({
+          coords: { latitude: 1.314, longitude: 103.765 },
+          timestamp: Date.now(),
+        } as GeolocationPosition);
+      }),
+    });
+
+    render(<SOSButton />);
+    fireEvent.click(screen.getByRole("button", { name: "SOS Emergency" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Share My Location/ })).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Share My Location/ }));
+
+    expect(shareMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "SOS - My Location",
+        text: expect.stringContaining("https://maps.google.com/?q=1.314,103.765"),
+      }),
+    );
+
+    Object.defineProperty(navigator, "share", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("falls back to SMS when Web Share is unavailable", async () => {
+    Object.defineProperty(navigator, "share", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    const openMock = vi.fn();
+    vi.stubGlobal("open", openMock);
+
+    mockGeolocation({
+      getCurrentPosition: vi.fn((success) => {
+        success({
+          coords: { latitude: 1.314, longitude: 103.765 },
+          timestamp: Date.now(),
+        } as GeolocationPosition);
+      }),
+    });
+
+    render(<SOSButton />);
+    fireEvent.click(screen.getByRole("button", { name: "SOS Emergency" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Share My Location/ })).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Share My Location/ }));
+
+    expect(openMock).toHaveBeenCalledWith(
+      expect.stringContaining("sms:?body="),
+      "_self",
+    );
+  });
+
+  it("shows geolocation not supported error", () => {
+    Object.defineProperty(navigator, "geolocation", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    render(<SOSButton />);
+    fireEvent.click(screen.getByRole("button", { name: "SOS Emergency" }));
+
+    expect(screen.getByText(/not supported/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Added `SOSButton` component (`src/components/senior/SOSButton.tsx`) — fixed-position red 64px circle button in bottom-right corner, always visible
- On tap opens a modal with three options:
  - **Call Emergency (995)** — `tel:995` link
  - **Share My Location with Family** — gets GPS via Geolocation API, generates Google Maps link, uses Web Share API (falls back to SMS)
  - **I Am Here: [address]** — shows reverse-geocoded address in large text
- Big Cancel button to dismiss modal; also closes on Escape key
- Integrated into `AppShell.tsx` so it's always accessible across all views
- 13 tests covering: render, open/close, emergency call link, share via Web Share API, SMS fallback, geolocation error handling, reverse geocoding, Escape key dismiss

## Testing

- ESLint: clean
- Vitest: 823 tests passing (71 files), 0 errors